### PR TITLE
fix: correct link to raw Dockerfile, use master until next release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,21 +139,21 @@ EXPOSE 8080
 ENTRYPOINT ["./entrypoint.sh"]
 
 FROM nodejs-builder as rosetta-server-builder
-ARG CARDANO_ROSETTA_SERVER_VERSION=1.0.0
+ARG CARDANO_ROSETTA_VERSION=master
 RUN apt-get update && apt-get install git -y
-RUN git clone -b ${CARDANO_ROSETTA_SERVER_VERSION} https://github.com/input-output-hk/cardano-rosetta
+RUN git clone -b ${CARDANO_ROSETTA_VERSION} https://github.com/input-output-hk/cardano-rosetta
 WORKDIR /cardano-rosetta/cardano-rosetta-server
 RUN yarn --offline --frozen-lockfile --non-interactive
 RUN yarn build
 
 FROM nodejs-builder as rosetta-server-production-deps
-RUN mkdir -p /app/src
+RUN mkdir -p /app
 COPY --from=rosetta-server-builder /cardano-rosetta/cardano-rosetta-server/packages-cache /app/packages-cache
 COPY --from=rosetta-server-builder /cardano-rosetta/cardano-rosetta-server/.yarnrc \
   /cardano-rosetta/cardano-rosetta-server/yarn.lock \
   /cardano-rosetta/cardano-rosetta-server/package.json \
-  /app/src/
-WORKDIR /app/src
+  /app/
+WORKDIR /app
 RUN yarn --offline --frozen-lockfile --non-interactive --production
 
 FROM ubuntu-nodejs as cardano-rosetta-server

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ for [Cardano](https://cardano.org/).
 The Dockerfile can be [built anywhere](https://www.rosetta-api.org/docs/node_deployment.html#build-anywhere)
 
 ```console
-wget --secure-protocol=TLSv1_2 https://raw.githubusercontent.com/input-output-hk/cardano-rosetta/0.1.0/Dockerfile
+wget --secure-protocol=TLSv1_2 https://raw.githubusercontent.com/input-output-hk/cardano-rosetta/master/Dockerfile
 docker build -t cardano-rosetta:0.1.0 .
 ```
 
@@ -27,7 +27,7 @@ Mount a single volume into the [standard storage location](https://www.rosetta-a
 mapping the server port to the host.
 
 ```console
-docker run -p 8080:8080 -v cardano-mainnet:/data cardano-rosetta:0.0.1 cardano-rosetta-mainnet
+docker run -p 8080:8080 -v cardano:/data cardano-rosetta:0.1.0 cardano-rosetta
 ```
 ## Documentation
 


### PR DESCRIPTION
# Description

The link to access the spec-compliant Dockerfile is invalid, and the version referenced needs to be updated to pick up the changes to the Ubuntu deps that was recently fixed. There was also an invalid path in the `rosetta-server-builder` stage, that has gone undetected until now due to the `dev.Dockerfile` not using it.
# Proposed Solution
- Fixes the link
- Removes the `src` component of the invalid path
- Uses the master branch until the next release is made

