### PR TITLE
Fix/set binary envs, add cardano-node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -158,7 +158,9 @@ RUN yarn --offline --frozen-lockfile --non-interactive --production
 
 FROM ubuntu-nodejs as cardano-rosetta-server
 ARG NETWORK=mainnet
-COPY --from=haskell-builder /usr/local/bin/cardano-cli /usr/local/bin/
+COPY --from=haskell-builder /usr/local/bin/cardano-cli \
+  /usr/local/bin/cardano-node \
+  /usr/local/bin/
 COPY --from=rosetta-server-builder /cardano-rosetta/cardano-rosetta-server/dist /cardano-rosetta-server/dist
 COPY --from=rosetta-server-production-deps /app/node_modules /cardano-rosetta-server/node_modules
 COPY --from=rosetta-server-builder /cardano-rosetta/config/network/${NETWORK} /config/

--- a/cardano-rosetta-server/README.md
+++ b/cardano-rosetta-server/README.md
@@ -33,6 +33,7 @@ GENESIS_PATH="/etc/node/testnet-genesis.json"
 CARDANO_NODE_SOCKET_PATH=/tmp/node.socket
 # max amount of transactions to be returned in `/block` endpoint. Otherwise only hashes will be sent
 PAGE_SIZE=25
+DEFAULT_RELATIVE_TTL=1000
 ```
 
 ### Install packages from offline cache

--- a/cardano-rosetta-server/docker-compose.yml
+++ b/cardano-rosetta-server/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       target: cardano-rosetta-server-dev
     environment:
       - DB_CONNECTION_STRING=postgresql://postgres:notForProduction!@postgres:5432/cexplorer
+      - DEFAULT_RELATIVE_TTL=1000
       - GENESIS_PATH=/config/genesis/shelley.json
       - LOGGER_LEVEL=debug
       - PAGE_SIZE=30

--- a/cardano-rosetta-server/docker-compose.yml
+++ b/cardano-rosetta-server/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       dockerfile: dev.Dockerfile
       target: cardano-rosetta-server-dev
     environment:
+      - CARDANOCLI_PATH=/usr/local/bin/cardano-cli
+      - CARDANO_NODE_SOCKET_PATH=/node-ipc/node.socket
       - DB_CONNECTION_STRING=postgresql://postgres:notForProduction!@postgres:5432/cexplorer
       - DEFAULT_RELATIVE_TTL=1000
       - GENESIS_PATH=/config/genesis/shelley.json
@@ -77,6 +79,7 @@ services:
         max-file: "10"
     volumes:
       - ../config/network/${NETWORK:-mainnet}:/config
+      - node-ipc:/node-ipc
 secrets:
   postgres_db:
     file: ./config/secrets/postgres_db

--- a/cardano-rosetta-server/docker-compose.yml
+++ b/cardano-rosetta-server/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       target: cardano-rosetta-server-dev
     environment:
       - CARDANOCLI_PATH=/usr/local/bin/cardano-cli
+      - CARDANO_NODE_PATH=/usr/local/bin/cardano-node
       - CARDANO_NODE_SOCKET_PATH=/node-ipc/node.socket
       - DB_CONNECTION_STRING=postgresql://postgres:notForProduction!@postgres:5432/cexplorer
       - DEFAULT_RELATIVE_TTL=1000

--- a/config/ecosystem.config.js
+++ b/config/ecosystem.config.js
@@ -41,13 +41,14 @@ module.exports = {
       },
       exec_mode: 'fork_mode',
       kill_timeout : 15000
-
     },
     {
       name: 'cardano-rosetta-server',
       script: '/cardano-rosetta-server/dist/src/server/index.js',
       autorestart: true,
       env: {
+        CARDANOCLI_PATH: '/usr/local/bin/cardano-cli',
+        CARDANO_NODE_SOCKET_PATH: '/ipc/node.socket',
         DB_CONNECTION_STRING: 'socket://postgres:*@/var/run/postgresql?db=cexplorer',
         DEFAULT_RELATIVE_TTL: 1000,
         GENESIS_PATH: '/config/genesis/shelley.json',

--- a/config/ecosystem.config.js
+++ b/config/ecosystem.config.js
@@ -49,6 +49,7 @@ module.exports = {
       autorestart: true,
       env: {
         DB_CONNECTION_STRING: 'socket://postgres:*@/var/run/postgresql?db=cexplorer',
+        DEFAULT_RELATIVE_TTL: 1000,
         GENESIS_PATH: '/config/genesis/shelley.json',
         LOGGER_LEVEL: 'debug',
         NODE_ENV: 'development',

--- a/config/ecosystem.config.js
+++ b/config/ecosystem.config.js
@@ -48,6 +48,7 @@ module.exports = {
       autorestart: true,
       env: {
         CARDANOCLI_PATH: '/usr/local/bin/cardano-cli',
+        CARDANO_NODE_PATH: '/usr/local/bin/cardano-node',
         CARDANO_NODE_SOCKET_PATH: '/ipc/node.socket',
         DB_CONNECTION_STRING: 'socket://postgres:*@/var/run/postgresql?db=cexplorer',
         DEFAULT_RELATIVE_TTL: 1000,

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -15,13 +15,18 @@ RUN yarn build
 FROM nodejs-builder as rosetta-server-production-deps-dev
 RUN mkdir -p /app/src
 COPY --from=rosetta-server-builder-dev /app/packages-cache /app/packages-cache
-COPY --from=rosetta-server-builder-dev /app/.yarnrc /app/yarn.lock /app/package.json /app/
+COPY --from=rosetta-server-builder-dev /app/.yarnrc \
+  /app/yarn.lock \
+  /app/package.json \
+  /app/
 WORKDIR /app
 RUN yarn --offline --frozen-lockfile --non-interactive --production
 
 FROM ubuntu-nodejs as cardano-rosetta-server-dev
 ARG NETWORK=mainnet
-COPY --from=haskell-builder /usr/local/bin/cardano-cli /usr/local/bin/
+COPY --from=haskell-builder /usr/local/bin/cardano-cli \
+  /usr/local/bin/cardano-node \
+  /usr/local/bin/
 COPY --from=rosetta-server-builder-dev /app/dist /cardano-rosetta-server/dist
 COPY --from=rosetta-server-production-deps-dev /app/node_modules /cardano-rosetta-server/node_modules
 COPY config/network/${NETWORK} /config/


### PR DESCRIPTION
# Description
Required ENVs are missing from the `cardano-rosetta-server` implementations in the Dockerfile:

- `DEFAULT_RELATIVE_TTL`
- `CARDANOCLI_PATH`
- `CARDANO_NODE_SOCKET_PATH`

It's also important to enable https://github.com/input-output-hk/cardano-rosetta/issues/28  

# Proposed Solution
- Adds the ENVS Closes #145 
- Adds `cardano-node` to the `cardano-rosetta-server` Dockerfile stage Closes #28 



