### PR TITLE
ci: Add data cache update workflow for use in CI

### DIFF
--- a/.github/actions/build_cardano_rosetta/action.yml
+++ b/.github/actions/build_cardano_rosetta/action.yml
@@ -1,0 +1,27 @@
+name: 'Build Cardano Rosetta'
+description: 'Builds the Dockerfile using a remote cache'
+inputs:
+  cardano-rosetta-version:
+    description: 'Software version'
+    required: false
+    default: 'master'
+  build-cache-image:
+    description: 'From the Docker registry, including tag'
+    required: false
+    default: 'inputoutput/cardano-rosetta:master'
+runs:
+  using: "composite"
+  steps:
+    - name: Build remote Dockerile using cache
+      run: wget --secure-protocol=TLSv1_2
+        -O- https://raw.githubusercontent.com/input-output-hk/cardano-rosetta/${{ inputs.cardano-rosetta-version }}/Dockerfile
+        | docker build --build-arg BUILDKIT_INLINE_CACHE=1
+          --cache-from ${{ inputs.build-cache-image }}
+          -t cardano-rosetta:master
+          -
+      shell: bash
+      env:
+        DOCKER_BUILDKIT: 1
+    - name: Setup sync directory
+      run: mkdir data
+      shell: bash

--- a/.github/workflows/update-data-cache.yml
+++ b/.github/workflows/update-data-cache.yml
@@ -1,0 +1,42 @@
+name: Update Data Cache
+
+on:
+  schedule:
+    - cron: '*/60 * * * *'
+
+jobs:
+  run-cardano-rosetta-for-five-minutes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - name: Build Cardano Rosetta
+        uses: ./.github/actions/build_cardano_rosetta
+        with:
+          build-cache-image: rhyslbw/cardano-rosetta:master
+      - name: Sync data cache
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks
+        env:
+          AWS_S3_BUCKET: 'cardano-rosetta-data-cache'
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SOURCE_DIR: 'data'
+      - name: Run Cardano Rosetta
+        run: docker run -d -v ${{ github.workspace }}/data:/data --name cardano-rosetta cardano-rosetta:master
+      - name: Wait one minute
+        run: sleep 60
+      - name: Stop Cardano Rosetta
+        run: |
+          docker stop cardano-rosetta
+          docker rm cardano-rosetta
+      - name: Upload new state
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks
+        env:
+          AWS_S3_BUCKET: 'cardano-rosetta-data-cache'
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SOURCE_DIR: 'data'


### PR DESCRIPTION
# Description
To implement https://github.com/input-output-hk/cardano-rosetta/issues/129 in a timely manner, a Docker build cache and recent data cache must be maintained to limit sync time to a reasonable duration. Running an instance 24/7 just to keep the data volumes up to date is overkill, so the workload should be intermittent.  

# Proposed Solution
- add Github Action to build Cardano Rosetta using cached build layers from a Docker Hub image.
- add workflow to run a Cardano Rosetta instance built from scratch using the cache, sync an S3 bucket containing a recent state, which is passes as a host mount
- after 1 minute shut down the instance and upload the new data.
- schedule to happen from the `master` branch` every hour

**N.B.** `rhyslbw/cardano-rosetta:master` is temporary until the `inputoutput` repository is created. ideally, the sync completion should be determined by reaching the tip, but this would require [SyncStatus](https://www.rosetta-api.org/docs/models/SyncStatus.html), which is not implemented. 

# Testing
Already tested by triggering the Workflow on pushes to this branch:
https://github.com/input-output-hk/cardano-rosetta/actions/runs/230905134


