### PR TITLE
fix: generic error handling

### DIFF
--- a/cardano-rosetta-server/src/server/api-error.ts
+++ b/cardano-rosetta-server/src/server/api-error.ts
@@ -7,7 +7,6 @@ interface Details {
  */
 export default class ApiError extends Error implements Components.Schemas.Error {
   code: number;
-  message: string;
   retriable: boolean;
   details?: Details;
 

--- a/cardano-rosetta-server/src/server/utils/errors.ts
+++ b/cardano-rosetta-server/src/server/utils/errors.ts
@@ -32,7 +32,7 @@ export const Errors = {
     message: 'Transaction outputs parameters errors in operations array',
     code: 4009
   },
-  OUPUTS_BIGGER_THAN_INPUTS_ERROR: {
+  OUTPUTS_BIGGER_THAN_INPUTS_ERROR: {
     message: 'The transaction you are trying to build has more outputs than inputs',
     code: 4010
   },
@@ -52,6 +52,7 @@ export const Errors = {
     message: 'Cant deserialize transaction output from transaction body',
     code: 4014
   },
+  UNSPECIFIED_ERROR: { message: 'An error occurred', code: 5000 },
   NOT_IMPLEMENTED: { message: 'Not implemented', code: 5001 },
   ADDRESS_GENERATION_ERROR: { message: 'Address generation error', code: 5002 },
   PARSE_SIGNED_TRANSACTION_ERROR: { message: 'Parse signed transaction error', code: 5003 },
@@ -70,12 +71,13 @@ export const buildApiError = (error: Error, retriable: boolean, details?: string
   new ApiError(error.code, error.message, retriable, details);
 
 type CreateErrorFunction = (details?: string) => ApiError;
-type CreateServerErrorFcuntion = () => ServerError;
+type CreateServerErrorFunction = () => ServerError;
 const blockNotFoundError: CreateErrorFunction = () => buildApiError(Errors.BLOCK_NOT_FOUND, false);
 const invalidBlockchainError: CreateErrorFunction = () => buildApiError(Errors.INVALID_BLOCKCHAIN, false);
 const networkNotFoundError: CreateErrorFunction = () => buildApiError(Errors.NETWORK_NOT_FOUND, false);
 const networksNotFoundError: CreateErrorFunction = () => buildApiError(Errors.NETWORKS_NOT_FOUND, false);
-const notImplentedError: CreateErrorFunction = () => buildApiError(Errors.NOT_IMPLEMENTED, false);
+const unspecifiedError: CreateErrorFunction = details => buildApiError(Errors.UNSPECIFIED_ERROR, true, details);
+const notImplementedError: CreateErrorFunction = () => buildApiError(Errors.NOT_IMPLEMENTED, false);
 const genesisBlockNotFound: CreateErrorFunction = () => buildApiError(Errors.GENESIS_BLOCK_NOT_FOUND, false);
 const transactionNotFound: CreateErrorFunction = () => buildApiError(Errors.TRANSACTION_NOT_FOUND, false);
 const addressGenerationError: CreateErrorFunction = () => buildApiError(Errors.ADDRESS_GENERATION_ERROR, false);
@@ -89,7 +91,7 @@ const transactionInputsParametersMissingError: CreateErrorFunction = (details?: 
 const transactionOutputsParametersMissingError: CreateErrorFunction = (details?: string) =>
   buildApiError(Errors.TRANSACTION_OUTPUTS_PARAMETERS_MISSING_ERROR, false, details);
 const outputsAreBiggerThanInputsError: CreateErrorFunction = () =>
-  buildApiError(Errors.OUPUTS_BIGGER_THAN_INPUTS_ERROR, false);
+  buildApiError(Errors.OUTPUTS_BIGGER_THAN_INPUTS_ERROR, false);
 const cantCreateSignedTransactionFromBytes: CreateErrorFunction = () =>
   buildApiError(Errors.CANT_CREATE_SIGNED_TRANSACTION_ERROR, false);
 const cantCreateUnsignedTransactionFromBytes: CreateErrorFunction = () =>
@@ -106,7 +108,8 @@ export const ErrorFactory = {
   networkNotFoundError,
   invalidBlockchainError,
   networksNotFoundError,
-  notImplentedError,
+  unspecifiedError,
+  notImplementedError,
   genesisBlockNotFound,
   transactionNotFound,
   addressGenerationError,
@@ -124,5 +127,5 @@ export const ErrorFactory = {
   transactionOutputDeserializationError
 };
 
-export const configNotFoundError: CreateServerErrorFcuntion = () =>
+export const configNotFoundError: CreateServerErrorFunction = () =>
   new ServerError('Environment configurations needed to run server were not found');

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -73,6 +73,11 @@ const allow = {
       retriable: false
     },
     {
+      code: 5000,
+      message: 'An error occurred',
+      retriable: true
+    },
+    {
       code: 5001,
       message: 'Not implemented',
       retriable: false

--- a/cardano-rosetta-server/test/e2e/server/server.test.ts
+++ b/cardano-rosetta-server/test/e2e/server/server.test.ts
@@ -1,0 +1,61 @@
+/* eslint-disable no-magic-numbers */
+import { FastifyInstance } from 'fastify';
+import StatusCodes from 'http-status-codes';
+import { Pool } from 'pg';
+import {
+  block1,
+  block1000WithoutTxs,
+  block23236WithTransactions,
+  block7134WithTxs,
+  blockWith8Txs,
+  GENESIS_HASH,
+  latestBlock
+} from '../fixture-data';
+import { setupDatabase, setupServer } from '../utils/test-utils';
+import { generateNetworkPayload } from '../network/common';
+import { CARDANO, MAINNET } from '../../../src/server/utils/constants';
+
+describe('Server test', () => {
+  let database: Pool;
+  let server: FastifyInstance;
+  beforeAll(async () => {
+    database = setupDatabase(false);
+    server = setupServer(database);
+  });
+
+  afterAll(async () => {
+    await database.end();
+  });
+
+  const genericErrorMatcher = expect.objectContaining({
+    code: 5000,
+    details: {
+      message: expect.stringContaining('An error occurred for request')
+    },
+    message: 'An error occurred',
+    retriable: true
+  });
+
+  test('should return a generic error if payload is not valid', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: '/block',
+      payload: '{ asdasd }'
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual(genericErrorMatcher);
+  });
+
+  test('should return a generic error if there is db connection problem', async () => {
+    await database.end();
+    const response = await server.inject({
+      method: 'post',
+      url: '/network/status',
+      payload: generateNetworkPayload(CARDANO, MAINNET)
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual(genericErrorMatcher);
+  });
+});


### PR DESCRIPTION
# Description

Without this change any non handled error would make the server crash as it was not returning a required by schema field.

# Proposed Solution

- Improved error handling code in server
- Added some missing tests to verify everything works as expected

# Important Changes Introduced

n/a

# Testing

`yarn test`

