### PR TITLE
docs: Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,28 @@
 # Cardano Rosetta
-![CI](https://github.com/input-output-hk/cardano-rosetta/workflows/CI/badge.svg) ![Nightly](https://github.com/input-output-hk/cardano-rosetta/workflows/Nightly/badge.svg)
+[![CI][img_src_CI]][workflow_CI] [![Nightly][img_src_Nightly]][workflow_Nightly]
 
 An implementation of [Rosetta 1.4.1] for [Cardano].
 
 ## Build
 
-The Dockerfile can be [built anywhere], initially taking around 30 minutes. 
+The Dockerfile can be [built anywhere], initially taking around 30 minutes:
 
 ```console
 wget --secure-protocol=TLSv1_2 \
-  -O- https://raw.githubusercontent.com/input-output-hk/cardano-rosetta/master/Dockerfile \
+  -O- https://raw.githubusercontent.com/input-output-hk/cardano-rosetta/0.2.0/Dockerfile \
   | docker build \
     -t cardano-rosetta:0.2.0 -
 ```
-With cached build layers, useful for non-production use-cases:
+**_Optionally_**  specify a [network] name, other than `mainnet`, using a build argument:
+
+```console
+  --build-arg=NETWORK=testnet
+```
+
+**_Optionally_** with cached build layers, useful for non-production use-cases:
 ```console
 wget --secure-protocol=TLSv1_2 \
-  -O- https://raw.githubusercontent.com/input-output-hk/cardano-rosetta/master/Dockerfile \
+  -O- https://raw.githubusercontent.com/input-output-hk/cardano-rosetta/0.2.0/Dockerfile \
   | DOCKER_BUILDKIT=1 \
   docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
@@ -24,42 +30,46 @@ wget --secure-protocol=TLSv1_2 \
     -t cardano-rosetta:0.2.0 -
 ```
 
-**_Optionally_**  specify a network name, or override the managed dependencies using build args
-flags in the `docker build` command. [See releases](docs/MAINTAINER.md#Internal-Software), and 
-[networks](config/network). `NETWORK` defaults to `mainnet`
-
-```console
-  --build-arg=NETWORK=testnet
-  --build-arg=A_DEP_VERSION=2.0.1
-```
-
 ## Run
 
-Mount a single volume into the [standard storage location](https://www.rosetta-api.org/docs/standard_storage_location.html) 
-mapping the server port to the host.
+Mount a single volume into the [standard storage location] mapping the server port to the host. 
+See the complete [Docker run reference] for full control. 
 
 ```console
-docker run -p 8080:8080 -v cardano-rosetta:/data --name cardano-rosetta cardano-rosetta:0.2.0 
+docker run \
+  --name cardano-rosetta \
+  -p 8080:8080 \
+  -v cardano-rosetta:/data \
+  cardano-rosetta:0.2.0 
 ```
+
+
 ## Documentation
 
-| Link                                                                                               | Audience                                                     |
-| ---                                                                                                | ---                                                          |
-| [Construction API Documentation]                                                                   | Users of the Cardano Rosetta Construction API                |
-| [Data API Documentation]                                                                           | Users of the Cardano Rosetta Data API                        |
-| [Developer]                                                                                        | Core or external developers of cardano-rosetta-server        |
-| [Maintainer]                                                                                       | Solution maintainer                                          |
-| [QA]                                                                                               | Quality Assurance Engineers                                  |
+| Link                               | Audience                                                     |
+| ---                                | ---                                                          |
+| [Construction API Documentation]   | Users of the Cardano Rosetta Construction API                |
+| [Data API Documentation]           | Users of the Cardano Rosetta Data API                        |
+| [Developer]                        | Core or external developers of cardano-rosetta-server        |
+| [Maintainer]                       | Solution maintainer                                          |
+| [QA]                               | Quality Assurance Engineers                                  |
 
 <hr/>
 
 <p align="center">
-  <a href="https://github.com/input-output-hk/cardano-rosetta/blob/master/LICENSE"><img src="https://img.shields.io/github/license/input-output-hk/cardano-rosetta.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/input-output-hk/cardano-rosetta/blob/master/LICENSE.md"><img src="https://img.shields.io/github/license/input-output-hk/cardano-rosetta.svg?style=for-the-badge" /></a>
 </p>
 
+[img_src_CI]: https://github.com/input-output-hk/cardano-rosetta/workflows/CI/badge.svg
+[workflow_CI]: https://github.com/input-output-hk/cardano-rosetta/actions?query=workflow%3ACI
+[img_src_Nightly]: https://github.com/input-output-hk/cardano-rosetta/workflows/Nightly/badge.svg
+[workflow_Nightly]: https://github.com/input-output-hk/cardano-rosetta/actions?query=workflow%3ANightly
 [Rosetta 1.4.1]: https://www.rosetta-api.org/docs/1.4.1/welcome.html
 [Cardano]: https://cardano.org/
 [built anywhere]: https://www.rosetta-api.org/docs/node_deployment.html#build-anywhere
+[network]: config/network
+[standard storage location]: https://www.rosetta-api.org/docs/standard_storage_location.html
+[Docker run reference]: https://docs.docker.com/engine/reference/run/
 [Construction API Documentation]: https://www.rosetta-api.org/docs/construction_api_introduction.html
 [Data API Documentation]: https://www.rosetta-api.org/docs/data_api_introduction.html
 [Developer]: cardano-rosetta-server/README.md


### PR DESCRIPTION
# Description
The `wget` command needs to specify the most current release ref. In the process of updating this I've take the opportunity to address some other issues, and add value.

# Proposed Solution
- correct Dockerfile version from `master` to `0.2.0`
- fix malformed license badge link
- add badge links
- reformat the run command to align with the build, and better document,
the arguments.
- remove build arg suggesting overriding internal dependencies is a user-facing feature
- position network selection as the priority over the cache use