### PR TITLE
Revert "Uncomment tests in nightly.yml (#161)", add context

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,17 +48,19 @@ jobs:
           rosetta-cli configuration:validate ../out/data_byron.json
           jq -s '.[0] * .[1] * .[2] * .[3]' base.json network/mainnet.json host/localhost.json data/shelley_transition_sample.json > ../out/data_shelley_transition.json
           rosetta-cli configuration:validate ../out/data_shelley_transition.json
-          jq -s '.[0] * .[1] * .[2] * .[3]' base.json network/mainnet.json host/localhost.json data/shelley_sample.json > ../out/data_shelley.json
-          rosetta-cli configuration:validate ../out/data_shelley.json
+# The disabled check are passing, but we're experiencing suspected false negatives:
+# https://github.com/coinbase/rosetta-cli/issues/124
+#          jq -s '.[0] * .[1] * .[2] * .[3]' base.json network/mainnet.json host/localhost.json data/shelley_sample.json > ../out/data_shelley.json
+#          rosetta-cli configuration:validate ../out/data_shelley.json
       - name: check:data byron
         working-directory: cardano-rosetta/test/check/configuration/out
         run: rosetta-cli check:data --configuration-file=data_byron.json
       - name: check:data shelley transition
         working-directory: cardano-rosetta/test/check/configuration/out
         run: rosetta-cli check:data --configuration-file=data_shelley_transition.json
-      - name: check:data shelley
-        working-directory: cardano-rosetta/test/check/configuration/out
-        run: rosetta-cli check:data --configuration-file=data_shelley.json
+#      - name: check:data shelley
+#        working-directory: cardano-rosetta/test/check/configuration/out
+#        run: rosetta-cli check:data --configuration-file=data_shelley.json
       - name: Make data snapshot
         env:
           AWS_S3_BUCKET: 'cardano-data-cache'


### PR DESCRIPTION
# Description

Until https://github.com/coinbase/rosetta-cli/issues/124 is addressed, it's best to keep this `check` disabled to avoid tarnishing the nightly test result.
# Proposed Solution
- Revert 368b0bc56a9f41f97fa17861b59adede17908711 
- Add comment with link for context
