### PR TITLE
Docker Hub Continuous Deployment + Manual dispatched pre-release workflow

### DIFF
--- a/.github/actions/build_cardano_rosetta/action.yml
+++ b/.github/actions/build_cardano_rosetta/action.yml
@@ -1,16 +1,16 @@
-name: 'Build Cardano Rosetta'
-description: 'Builds the Dockerfile using a remote cache'
+name: Build Cardano Rosetta
+description: Builds the Dockerfile using a remote cache
 inputs:
   cardano-rosetta-version:
-    description: 'Software version'
+    description: Software version
     required: false
-    default: 'master'
+    default: master
   build-cache-image:
-    description: 'From the Docker registry, including tag'
+    description: From the Docker registry, including tag
     required: false
-    default: 'inputoutput/cardano-rosetta:master'
+    default: inputoutput/cardano-rosetta:master
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Build remote Dockerile using cache
       run: wget --secure-protocol=TLSv1_2

--- a/.github/actions/smoke_test_cardano_rosetta/action.yml
+++ b/.github/actions/smoke_test_cardano_rosetta/action.yml
@@ -1,0 +1,23 @@
+name: Smoke Test Cardano Rosetta
+description: Runs the image, waits, then performs a basic smoke test
+inputs:
+  cardano-rosetta-version:
+    description: Software version
+    required: false
+    default: master
+  network-identifier:
+    description: Name of the network to query
+    required: false
+    default: master
+runs:
+  using: composite
+  steps:
+    - name: Run
+      run: docker run -d -p 8080:8080 --name cardano-rosetta cardano-rosetta:${{ inputs.cardano-rosetta-version }}
+      shell: bash
+    - name: Test
+      run: |
+        sleep 10
+        curl -X POST -H "Content-Type: application/json" -d '{"network_identifier":{"blockchain": "cardano", "network":"${{ inputs.network-identifier }}"}}' http://localhost:8080/network/status
+        docker rm -f cardano-rosetta
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
 name: CI
 
 on:
-  push:
-    branches: [master]
   pull_request:
-    branches: [master]
+    branches:
+      - master
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ jobs:
         with:
           cardano-rosetta-version: ${{ github.sha }}
       - name: Smoke test Cardano Rosetta image
-        run: |
-          docker run -d -p 8080:8080 --name cardano-rosetta cardano-rosetta:${{ github.sha }}
-          sleep 10
-          curl -X POST -H "Content-Type: application/json" -d '{"network_identifier":{"blockchain": "cardano", "network":"mainnet"}}' http://localhost:8080/network/status
-          docker stop cardano-rosetta
+        uses: ./cardano-rosetta/.github/actions/smoke_test_cardano_rosetta
+        with:
+          cardano-rosetta-version: ${{ github.sha }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,14 +11,14 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
         with:
-          path: 'cardano-rosetta'
+          path: cardano-rosetta
       - name: Build Cardano Rosetta
         uses: ./cardano-rosetta/.github/actions/build_cardano_rosetta
         with:
           cardano-rosetta-version: ${{ github.sha }}
       - name: Restore data snapshot
         env:
-          AWS_S3_BUCKET: 'cardano-data-cache'
+          AWS_S3_BUCKET: cardano-data-cache
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -63,7 +63,7 @@ jobs:
 #        run: rosetta-cli check:data --configuration-file=data_shelley.json
       - name: Make data snapshot
         env:
-          AWS_S3_BUCKET: 'cardano-data-cache'
+          AWS_S3_BUCKET: cardano-data-cache
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |

--- a/.github/workflows/post_integration.yml
+++ b/.github/workflows/post_integration.yml
@@ -1,0 +1,32 @@
+name: Post-integration
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  push-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - name: Build Cardano Rosetta
+        uses: .github/actions/build_cardano_rosetta
+        with:
+          cardano-rosetta-version: ${{ github.sha }}
+      - name: Smoke test Cardano Rosetta image
+        uses: .github/actions/smoke_test_cardano_rosetta
+        with:
+          cardano-rosetta-version: ${{ github.sha }}
+      - name: Apply master tag
+        run: docker tag inputoutput/cardano-rosetta:${{ github.sha }} inputoutput/cardano-rosetta:master
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Push to Docker Hub
+        run: |
+          docker push inputoutput/cardano-rosetta:${{ github.sha }}
+          docker push inputoutput/cardano-rosetta:master

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -1,0 +1,32 @@
+name: Post-release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build-and-push-release-builds:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - name: Build Cardano Rosetta
+        uses: .github/actions/build_cardano_rosetta
+        with:
+          cardano-rosetta-version: ${{ github.ref }}
+      - name: Smoke test Cardano Rosetta image
+        uses: .github/actions/smoke_test_cardano_rosetta
+        with:
+          cardano-rosetta-version: ${{ github.sha }}
+      - name: Apply latest tag
+        run: docker tag inputoutput/cardano-rosetta:${{ github.sha }} inputoutput/cardano-rosetta:latest
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Push to Docker Hub
+        run: |
+          docker push inputoutput/cardano-rosetta:${{ github.ref }}
+          docker push inputoutput/cardano-rosetta:latest

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -1,0 +1,32 @@
+name: Pre-release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-builds:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - name: Build remote Dockerile without cache
+        run: wget --secure-protocol=TLSv1_2
+          -O- https://raw.githubusercontent.com/input-output-hk/cardano-rosetta/${{ github.ref }}/Dockerfile
+          | docker build
+            -t cardano-rosetta:${{ github.ref }}
+            -
+      - name: Smoke test remote build
+        uses: .github/actions/smoke_test_cardano_rosetta
+        with:
+          cardano-rosetta-version: ${{ github.sha }}
+      - name: Testnet build with local cache
+        run: wget --secure-protocol=TLSv1_2
+          -O- https://raw.githubusercontent.com/input-output-hk/cardano-rosetta/${{ github.ref }}/Dockerfile
+          | docker build --build-arg NETWORK=testnet
+            -t cardano-rosetta:${{ github.ref }}
+            -
+      - name: Smoke test remote testnet build with local cache
+        uses: .github/actions/smoke_test_cardano_rosetta
+        with:
+          cardano-rosetta-version: ${{ github.sha }}
+          network-identifier: testnet

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -1,17 +1,32 @@
 ## Internal Software
-- [cardano-node](https://github.com/input-output-hk/cardano-node/releases)
-- [cardano-db-sync](https://github.com/input-output-hk/cardano-db-sync/releases)
-- [PostgreSQL](https://www.postgresql.org/)
+- [cardano-node]
+- [cardano-db-sync]
+- [PostgreSQL]
 
 ## Process Management
-[PM2](https://pm2.keymetrics.io/docs/usage/docker-pm2-nodejs/) is used to manage Cardano Rosetta 
+[PM2] is used to manage Cardano Rosetta 
 processes within the container.
 
 ## Libsodium fork
-IOHK maintains a [fork of libsodium](https://github.com/input-output-hk/libsodium), which is built
- from source in the Dockerfile. To determine `IOHK_LIBSODIUM_GIT_REV`: 
+IOHK maintains a [fork of libsodium], which is built from source in the Dockerfile. To determine 
+`IOHK_LIBSODIUM_GIT_REV`: 
 1. Locate the git rev of `iohk-nix` in the `cardano-node` repo for the targeted version.
 2. Go to that rev and review /overlays/crypto/libsodium.nix
 
-For example, `cardano-node@1.19.0` has [`iohk-nix@b22d8da9dd38c971ad40d9ad2d1a60cce53995fb`](https://github.com/input-output-hk/cardano-node/blob/1.19.0/nix/sources.json#L44) pinned, 
-so the version of libsodium is [known to be 66f017f16633f2060db25e17c170c2afa0f2a8a1](https://github.com/input-output-hk/iohk-nix/blob/91b67f54420dabb229c58d16fb1d18e74f9e3c9e/overlays/crypto/libsodium.nix#L9)
+For example, `cardano-node@1.19.0` has [`iohk-nix@b22d8da9dd38c971ad40d9ad2d1a60cce53995fb`][1] pinned, 
+so the version of libsodium is [known to be 66f017f16633f2060db25e17c170c2afa0f2a8a1][2]
+
+## Continuous deployment to Docker Hub 
+Docker builds are pushed to Docker Hub in both the [post-integration workflow], and 
+[post-release workflow]. The former maintains the build cache source and can be useful during 
+testing, and the latter delivers versioned builds that also takes the `latest` tag.
+
+[cardano-node]: https://github.com/input-output-hk/cardano-node/releases
+[cardano-db-sync]: https://github.com/input-output-hk/cardano-db-sync/releases
+[PostgreSQL]: https://www.postgresql.org/
+[PM2]: https://pm2.keymetrics.io/docs/usage/docker-pm2-nodejs/
+[fork of libsodium]: https://github.com/input-output-hk/libsodium
+[1]: https://github.com/input-output-hk/cardano-node/blob/1.19.0/nix/sources.json#L44
+[2]: https://github.com/input-output-hk/iohk-nix/blob/91b67f54420dabb229c58d16fb1d18e74f9e3c9e/overlays/crypto/libsodium.nix#L9
+[post-integration workflow]: ../.github/workflows/post_integration.yml
+[post-release workflow]: ../.github/workflows/post_release.yml


### PR DESCRIPTION
# Description

We require builds to be pushed to Docker Hub, to maintain a current build cache, and make pre-built images available as a convenience. We also need assurance prior to release that a fresh build completes, without using the cache.

# Proposed Solution
- Adds three new Workflows:
  - produce the `master` branch build for the build cache
  - run and report results of a fresh build, then also build a testnet image using local cache
  - post-release to deploy versioned images as a convenience

Smoke tests performed prior to pushing. 

Closes #126 Closes #127 Closes #140 

# Testing
Automated testing is configured in the workflows, so testing will involve observing after the condition are triggered.
