### PR TITLE
ci: fix build context in post-release workflow

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Build Cardano Rosetta
         uses: ./.github/actions/build_cardano_rosetta
         with:
-          build-context: ${{ github.workspace }}/cardano-rosetta
+          build-context: ${{ github.workspace }}
           tag: ${{ github.event.release.tag_name }}
       - name: Smoke test Cardano Rosetta image
         uses: ./.github/actions/smoke_test_cardano_rosetta


### PR DESCRIPTION
# Description

The non-critical [post-release workflow failed](https://github.com/input-output-hk/cardano-rosetta/actions/runs/238697742) due to an invalid Docker build context path. It's not possible to test locally due to a [limitation with act](https://github.com/nektos/act/issues/339)
# Proposed Solution
Removes the invalid path component

# Testing

Only another release will validate this fully, but we expect to have more before `1.0.0`

