### PR TITLE
fix: account total balance was calculated using Number instead of BigInt

### DIFF
--- a/cardano-rosetta-server/src/server/controllers/account-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/account-controller.ts
@@ -26,7 +26,7 @@ const configure = (blockService: BlockService, networkId: string): AccountContro
           accountBalanceRequest.block_identifier?.index,
           accountBalanceRequest.block_identifier?.hash
         );
-        const toReturn = mapToAccountBalanceResponse(blockUtxos, accountAddress);
+        const toReturn = mapToAccountBalanceResponse(blockUtxos);
         logger.debug(toReturn, '[accountBalance] About to return ');
         return toReturn;
       },

--- a/cardano-rosetta-server/src/server/utils/data-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/data-mapper.ts
@@ -160,11 +160,10 @@ const parseUtxoDetails = (utxoDetails: Utxo[]): Components.Schemas.Coin[] =>
  * @param blockUtxos
  * @param accountAddress
  */
-export const mapToAccountBalanceResponse = (
-  blockUtxos: BlockUtxos,
-  accountAddress: string
-): Components.Schemas.AccountBalanceResponse => {
-  const balanceForAddress = blockUtxos.utxos.reduce((acum, current) => acum + Number(current.value), 0).toString();
+export const mapToAccountBalanceResponse = (blockUtxos: BlockUtxos): Components.Schemas.AccountBalanceResponse => {
+  const balanceForAddress = blockUtxos.utxos
+    .reduce((acum, current) => acum + BigInt(current.value), BigInt(0))
+    .toString();
   return {
     block_identifier: {
       index: blockUtxos.block.number,
@@ -176,9 +175,7 @@ export const mapToAccountBalanceResponse = (
         currency: {
           symbol: ADA,
           decimals: ADA_DECIMALS,
-          metadata: {
-            issuer: accountAddress
-          }
+          metadata: {}
         },
         metadata: {}
       }

--- a/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
@@ -1,0 +1,68 @@
+import { mapToAccountBalanceResponse } from '../../../src/server/utils/data-mapper';
+import { BlockUtxos } from '../../../src/server/models';
+
+describe('Data Mapper', () => {
+  describe('mapToAccountBalanceResponse', () => {
+    // Test case reported by Coinbase
+    // "error": "reconciliation failure: active reconciliation error for
+    // addr_test1vrd26p8d9dlknc4fhevzudcfzuul5qm2znquytugqcw583czzqrpm at
+    // 1630464 (computed: 37999999978288983ADA, live: 37999999978288984ADA)"
+    it('Should properly process BigInt balances', () => {
+      const blockUtxos: BlockUtxos = {
+        block: {
+          hash: '032349b3b569bc1ecb266b79ae28a5e79834377562a627f0dc99fa3cd1bfd546',
+          number: 1627535,
+          createdAt: new Date().getMilliseconds(), // not needed
+          previousBlockHash: '032349b3b569bc1ecb266b79ae28a5e79834377562a627f0dc99fa3cd1bfd546',
+          previousBlockNumber: 1627535,
+          transactionsCount: 1,
+          createdBy: '7ec249d',
+          size: 238,
+          epochNo: 75,
+          slotNo: 0 // not needed
+        },
+        utxos: [
+          {
+            value: '37999999989620601',
+            transactionHash: 'c09c523b0a94837dacf08e30f8cc6d5915786b883f822981ea2012551f8699ce',
+            index: 1
+          }
+        ]
+      };
+      const mapped = mapToAccountBalanceResponse(blockUtxos);
+      expect(mapped).toEqual({
+        balances: [
+          {
+            currency: {
+              decimals: 6,
+              metadata: {},
+              symbol: 'ADA'
+            },
+            metadata: {},
+            value: '37999999989620601'
+          }
+        ],
+        // eslint-disable-next-line camelcase
+        block_identifier: {
+          hash: '032349b3b569bc1ecb266b79ae28a5e79834377562a627f0dc99fa3cd1bfd546',
+          index: 1627535
+        },
+        coins: [
+          {
+            amount: {
+              currency: {
+                decimals: 6,
+                symbol: 'ADA'
+              },
+              value: '37999999989620601'
+            },
+            // eslint-disable-next-line camelcase
+            coin_identifier: {
+              identifier: 'c09c523b0a94837dacf08e30f8cc6d5915786b883f822981ea2012551f8699ce:1'
+            }
+          }
+        ]
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Description

Coinbase team has reported that there was an error when executing `check:data`

```json
{
 "error": "reconciliation failure: active reconciliation error for addr_test1vrd26p8d9dlknc4fhevzudcfzuul5qm2znquytugqcw583czzqrpm at 1630464 (computed: 37999999978288983ADA, live: 37999999978288984ADA)",
 "end_condition": null,
 "tests": {
  "request_response": true,
  "response_assertion": true,
  "block_syncing": true,
  "balance_tracking": true,
  "reconciliation": false
 },
 "stats": {
  "blocks": 4888313,
  "orphans": 0,
  "transactions": 60265,
  "operations": 241741,
  "active_reconciliations": 75757,
  "inactive_reconciliations": 6219979,
  "reconciliation_coverage": 0.007858546168958742
 }
}
```

# Proposed Solution

When calculating total balance, it was using a `Number` instead of a `BigInt`

# Important Changes Introduced

n/a

# Testing

`rosetta-cli check:data` for the blocks in the account`addr_test1vrd26p8d9dlknc4fhevzudcfzuul5qm2znquytugqcw583czzqrpm` transactions range.
