### PR TITLE
Feature/docker runtime config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,7 +171,7 @@ CMD ["node", "/cardano-rosetta-server/dist/src/server/index.js"]
 
 FROM runtime-base
 ARG NETWORK=mainnet
-ENV LOGGER_MIN_SEVERITY=info PAGE_SIZE=25
+ENV DEFAULT_RELATIVE_TTL=1000 LOGGER_MIN_SEVERITY=info PAGE_SIZE=25
 COPY --from=rosetta-server-builder /app/dist /cardano-rosetta-server/dist
 COPY --from=rosetta-server-production-deps /app/node_modules /cardano-rosetta-server/node_modules
 COPY config/ecosystem.config.js .

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,6 +171,7 @@ CMD ["node", "/cardano-rosetta-server/dist/src/server/index.js"]
 
 FROM runtime-base
 ARG NETWORK=mainnet
+ENV LOGGER_MIN_SEVERITY=info
 COPY --from=rosetta-server-builder /app/dist /cardano-rosetta-server/dist
 COPY --from=rosetta-server-production-deps /app/node_modules /cardano-rosetta-server/node_modules
 COPY config/ecosystem.config.js .

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,7 +171,7 @@ CMD ["node", "/cardano-rosetta-server/dist/src/server/index.js"]
 
 FROM runtime-base
 ARG NETWORK=mainnet
-ENV LOGGER_MIN_SEVERITY=info
+ENV LOGGER_MIN_SEVERITY=info PAGE_SIZE=25
 COPY --from=rosetta-server-builder /app/dist /cardano-rosetta-server/dist
 COPY --from=rosetta-server-production-deps /app/node_modules /cardano-rosetta-server/node_modules
 COPY config/ecosystem.config.js .

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ docker run \
   -v cardano-rosetta:/data \
   cardano-rosetta:0.2.1
 ```
-
+### Configuration
+```console
+-e LOGGER_MIN_SEVERITY=[ trace | debug | info (default) | warn | error | fatal ]
+```
 ## Documentation
 
 | Link                               | Audience                                                     |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ docker run \
 ```
 ### Configuration
 ```console
+-e DEFAULT_RELATIVE_TTL=1000
 -e LOGGER_MIN_SEVERITY=[ trace | debug | info (default) | warn | error | fatal ]
 -e PAGE_SIZE=25
 ```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ docker run \
 ### Configuration
 ```console
 -e LOGGER_MIN_SEVERITY=[ trace | debug | info (default) | warn | error | fatal ]
+-e PAGE_SIZE=25
 ```
 ## Documentation
 

--- a/cardano-rosetta-server/README.md
+++ b/cardano-rosetta-server/README.md
@@ -17,7 +17,7 @@ There must be a `.env` or `.env.test` file in the root directory with the follow
 ```
 # App port
 PORT=8080
-# Application log level {silent, fatal, error, warn, info, debug, trace, all}
+# Application log level [ trace | debug | info | warn | error | fatal ]
 LOGGER_LEVEL="debug"
 # App address to bind to
 BIND_ADDRESS=0.0.0.0

--- a/config/ecosystem.config.js
+++ b/config/ecosystem.config.js
@@ -54,7 +54,7 @@ module.exports = {
         DB_CONNECTION_STRING: 'socket://postgres:*@/var/run/postgresql?db=cexplorer',
         DEFAULT_RELATIVE_TTL: 1000,
         GENESIS_PATH: '/config/genesis/shelley.json',
-        LOGGER_LEVEL: 'debug',
+        LOGGER_LEVEL: process.env.LOGGER_MIN_SEVERITY,
         NODE_ENV: 'development',
         PAGE_SIZE: 30,
         PORT: 8080,

--- a/config/ecosystem.config.js
+++ b/config/ecosystem.config.js
@@ -56,7 +56,7 @@ module.exports = {
         GENESIS_PATH: '/config/genesis/shelley.json',
         LOGGER_LEVEL: process.env.LOGGER_MIN_SEVERITY,
         NODE_ENV: 'development',
-        PAGE_SIZE: 30,
+        PAGE_SIZE: process.env.PAGE_SIZE,
         PORT: 8080,
         TOPOLOGY_FILE_PATH: '/config/cardano-node/topology.json'
       },

--- a/config/ecosystem.config.js
+++ b/config/ecosystem.config.js
@@ -52,7 +52,7 @@ module.exports = {
         CARDANO_NODE_PATH: '/usr/local/bin/cardano-node',
         CARDANO_NODE_SOCKET_PATH: '/ipc/node.socket',
         DB_CONNECTION_STRING: 'socket://postgres:*@/var/run/postgresql?db=cexplorer',
-        DEFAULT_RELATIVE_TTL: 1000,
+        DEFAULT_RELATIVE_TTL: process.env.DEFAULT_RELATIVE_TTL,
         GENESIS_PATH: '/config/genesis/shelley.json',
         LOGGER_LEVEL: process.env.LOGGER_MIN_SEVERITY,
         NODE_ENV: 'development',


### PR DESCRIPTION
# Description
1. Some runtime configuration is being hard coded in the Docker environment
2. The default value for `PAGE_SIZE` varies from what the docs suggests.
3. There is an invalid list of logging options in docs 
Closes #155

# Proposed Solution
Defines `DEFAULT_RELATIVE_TTL`, `LOGGER_MIN_SEVERITY` and `PAGE_SIZE` as ENVs in the Dockerfile, and replaces the hard-coded values in the ecosystem config. Also adds and corrects documentation.

# Important Changes Introduced
`PAGE_SIZE` now defaults to `25` in the container, instead of `30`

# Testing

N/A
