### PR TITLE
fix: dont ask for socket file to exist when parsing env

### DIFF
--- a/cardano-rosetta-server/src/server/utils/environment-parser.ts
+++ b/cardano-rosetta-server/src/server/utils/environment-parser.ts
@@ -37,7 +37,7 @@ export const parseEnvironment = (): Environment => {
     PAGE_SIZE: num(),
     CARDANO_NODE_PATH: existingFileValidator(),
     GENESIS_PATH: existingFileValidator(),
-    CARDANO_NODE_SOCKET_PATH: existingFileValidator()
+    CARDANO_NODE_SOCKET_PATH: str()
   });
   let topologyFile: TopologyConfig;
   try {


### PR DESCRIPTION
# Description

Socket seems not to be created when launching the app so it errors out

# Proposed Solution

We just check it's a string now

# Important Changes Introduced

n/a

# Testing

n/a

