### PR TITLE
fix: strengthen Docker smoke test

### DIFF
--- a/.github/actions/smoke_test_cardano_rosetta/action.yml
+++ b/.github/actions/smoke_test_cardano_rosetta/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: Supported Cardano network
     required: false
     default: mainnet
+  test-exe:
+    description: Smoke test executable
+    required: true
 runs:
   using: composite
   steps:
@@ -18,6 +21,6 @@ runs:
     - name: Test
       run: |
         sleep 10
-        curl -X POST -H "Content-Type: application/json" -d '{"network_identifier":{"blockchain": "cardano", "network":"${{ inputs.network-identifier }}"}}' http://localhost:8080/network/status
+        ${{ inputs.test-exe }} ${{ inputs.network-identifier }}
         docker stop cardano-rosetta
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,4 @@ jobs:
         uses: ./cardano-rosetta/.github/actions/smoke_test_cardano_rosetta
         with:
           tag: ${{ github.sha }}
+          test-exe:  ./cardano-rosetta/test/smoke_test.sh

--- a/.github/workflows/post_integration.yml
+++ b/.github/workflows/post_integration.yml
@@ -20,6 +20,7 @@ jobs:
         uses: ./.github/actions/smoke_test_cardano_rosetta
         with:
           tag: ${{ github.sha }}
+          test-exe: ./test/smoke_test.sh
       - name: Apply master tag
         run: |
           docker tag cardano-rosetta:${{ github.sha }} inputoutput/cardano-rosetta:${{ github.sha }}

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -20,6 +20,7 @@ jobs:
         uses: ./.github/actions/smoke_test_cardano_rosetta
         with:
           tag: ${{ github.event.release.tag_name }}
+          test-exe: ./test/smoke_test.sh
       - name: Apply latest tag
         run: |
           docker tag cardano-rosetta:${{ github.event.release.tag_name }} inputoutput/cardano-rosetta:${{ github.event.release.tag_name }}

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -27,3 +27,4 @@ jobs:
         with:
           tag: ${{ github.sha }}
           network-identifier: testnet
+          test-exe: ./test/smoke_test.sh

--- a/test/smoke_test.sh
+++ b/test/smoke_test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+NETWORK_IDENTIFIER=$1
+
+function queryNetworkStatus () {
+  curl \
+    --retry-connrefused \
+    --retry 10 \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"network_identifier":{"blockchain": "cardano", "network":"'${NETWORK_IDENTIFIER}'"}}' http://localhost:8080/network/status
+}
+
+if ! type "jq" > /dev/null
+ then
+  echo "jq is a system requirement, but is not found on PATH. https://stedolan.github.io/jq/download/"
+else
+  i="0"
+  while [ $i -lt 19 ]
+  do
+    result=$(queryNetworkStatus)
+    echo $result | jq .
+    if [[ $(echo $result | jq '.code == 5000') == true ]]
+    then
+      echo 'Will retry in 3 seconds'
+      i=$[$i+1]
+      sleep 3
+    else
+      echo $result | jq -e '.current_block_identifier.index != null' > /dev/null
+      exit
+    fi
+  done
+fi


### PR DESCRIPTION
# Description

Closes #180

# Proposed Solution
- lift logic to bash script for portability
- check for readiness, retry every 3 seconds
- check for block index property existence

# Important Changes Introduced


# Testing

Automated - See result of this CI run [here](https://github.com/input-output-hk/cardano-rosetta/pull/181/checks?check_run_id=1100694743)

