### PR TITLE
Docs/specify shm size in run

### DIFF
--- a/.github/actions/smoke_test_cardano_rosetta/action.yml
+++ b/.github/actions/smoke_test_cardano_rosetta/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Run
-      run: docker run --rm -d -p 8080:8080 --name cardano-rosetta cardano-rosetta:${{ inputs.tag }}
+      run: docker run --rm -d -p 8080:8080 --name cardano-rosetta --shm-size=2g cardano-rosetta:${{ inputs.tag }}
       shell: bash
     - name: Test
       run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
           tar xvf data.tar data
           rm data.tar
       - name: Run Cardano Rosetta
-        run: docker run --rm -d -p 8080:8080 -v ${{ github.workspace }}/data:/data --name cardano-rosetta cardano-rosetta:${{ github.sha }}
+        run: docker run --rm -d -p 8080:8080 -v ${{ github.workspace }}/data:/data --name cardano-rosetta --shm-size=2g cardano-rosetta:${{ github.sha }}
       - name: Setup Go
         uses: actions/setup-go@v2
         with:

--- a/README.md
+++ b/README.md
@@ -34,14 +34,16 @@ docker build \
 
 ## Run
 
-Mount a single volume into the [standard storage location] mapping the server port to the host. 
-See the complete [Docker run reference] for full control. 
+Mount a single volume into the [standard storage location], mapping the server port to the host, 
+and allocating a suitably-sized `/dev/shm`. See the complete [Docker run reference] for full 
+control.
 
 ```console
 docker run \
   --name cardano-rosetta \
   -p 8080:8080 \
   -v cardano-rosetta:/data \
+  --shm-size=2g \
   cardano-rosetta:0.2.2
 ```
 ### Configuration


### PR DESCRIPTION
# Description
The postgres process can demands more than the container default /dev/shm resource allocation of 64MB under moderate load, but our docs and automated tests are not specifying more.

# Proposed Solution
Include a 2GB allocation in the `docker run` command in docs and workflows. This value was previously determined via profiling, and is set elsewhere in docker-compose files including [our own](https://github.com/input-output-hk/cardano-rosetta/blob/master/cardano-rosetta-server/docker-compose.yml#L15), and other projects such as https://github.com/input-output-hk/cardano-graphql/blob/master/docker-compose.yml#L17

https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources

# Testing
 Will be performed by the workflows

