### PR TITLE
fix: don't repeat witnesses if multiple inputs from the same address are used

### DIFF
--- a/cardano-rosetta-server/src/server/services/cardano-services.ts
+++ b/cardano-rosetta-server/src/server/services/cardano-services.ts
@@ -383,12 +383,14 @@ const configure = (linearFeeParameters: LinearFeeParameters): CardanoService => 
       ttl
     );
     logger.info('[createUnsignedTransaction] Extracting addresses that will sign transaction from inputs');
-    const addresses = inputs.map(input => {
-      if (input.account) return input.account?.address;
-      // This logic is not necessary (because it is made on this.getTransactionInputs(..))
-      // but ts expects me to do it again
-      throw ErrorFactory.transactionInputsParametersMissingError('Input has missing account address field');
-    });
+    const addresses = getUniqueAddresses(
+      inputs.map(input => {
+        if (input.account) return input.account?.address;
+        // This logic is not necessary (because it is made on this.getTransactionInputs(..))
+        // but ts expects me to do it again
+        throw ErrorFactory.transactionInputsParametersMissingError('Input has missing account address field');
+      })
+    );
 
     const transactionBytes = hexFormatter(Buffer.from(transactionBody.to_bytes()));
     logger.info('[createUnsignedTransaction] Hashing transaction body');

--- a/cardano-rosetta-server/test/e2e/construction/cosntruction-payloads-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/cosntruction-payloads-api.test.ts
@@ -4,6 +4,7 @@ import { Pool } from 'pg';
 import { FastifyInstance } from 'fastify';
 import { setupDatabase, setupServer, testInvalidNetworkParameters } from '../utils/test-utils';
 import {
+  CONSTRUCTION_PAYLOADS_MULTIPLE_INPUTS,
   CONSTRUCTION_PAYLOADS_REQUEST,
   CONSTRUCTION_PAYLOADS_REQUEST_INVALID_INPUTS,
   CONSTRUCTION_PAYLOADS_REQUEST_INVALID_OUTPUTS,
@@ -55,6 +56,16 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
         }
       ]
     });
+  });
+
+  test('Should return a single payload for each input address', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_PAYLOADS_ENDPOINT,
+      payload: CONSTRUCTION_PAYLOADS_MULTIPLE_INPUTS
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json().payloads.length).toEqual(1);
   });
 
   test('Should throw an error when invalid inputs are sent as parameters', async () => {

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -508,6 +508,118 @@ export const CONSTRUCTION_PAYLOADS_REQUEST = {
   }
 };
 
+export const CONSTRUCTION_PAYLOADS_MULTIPLE_INPUTS = {
+  network_identifier: {
+    blockchain: 'cardano',
+    network: 'mainnet'
+  },
+  operations: [
+    {
+      operation_identifier: {
+        index: 0,
+        network_index: 0
+      },
+      type: 'transfer',
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '-90000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      },
+      coin_change: {
+        coin_identifier: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          identifier: '2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1'
+        },
+        coin_action: 'coin_spent'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 1,
+        network_index: 0
+      },
+      type: 'transfer',
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '-10000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      },
+      coin_change: {
+        coin_identifier: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          identifier: '2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1'
+        },
+        coin_action: 'coin_spent'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 2
+      },
+      related_operations: [
+        {
+          index: 0
+        },
+        {
+          index: 1
+        }
+      ],
+      type: 'transfer',
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '10000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      related_operations: [
+        {
+          index: 0
+        },
+        {
+          index: 1
+        }
+      ],
+      type: 'transfer',
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '40000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    }
+  ],
+  metadata: {
+    ttl: 1000
+  }
+};
+
 const CONSTRUCTION_EXTRA_DATA = CONSTRUCTION_PAYLOADS_REQUEST.operations.filter(
   op => op.coin_change?.coin_action === 'coin_spent'
 );


### PR DESCRIPTION
# Description

closes #184

# Proposed Solution

Just filter duplicated addresses

# Important Changes Introduced

n/a

# Testing

Use the example project and send to transactions to the generated address before executing `yarn send-transactions-example` so it uses to inputs

