### PR TITLE
Revert "chore: downgrade Docker image base to Ubuntu 18.04"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG UBUNTU_VERSION=18.04
+ARG UBUNTU_VERSION=20.04
 FROM ubuntu:${UBUNTU_VERSION} as haskell-builder
 ARG CABAL_VERSION=3.2.0.0
 ARG CARDANO_NODE_VERSION=1.21.1
@@ -9,25 +9,25 @@ ENV DEBIAN_FRONTEND=nonintercative
 RUN mkdir -p /app/src
 WORKDIR /app
 RUN apt-get update -y && apt-get install -y \
-  automake=1:1.15.1-3ubuntu2 \
+  automake=1:1.16.1-4ubuntu6 \
   build-essential \
-  g++=4:7.4.0-1ubuntu2.3 \
+  g++=4:9.3.0-1ubuntu2 \
   git \
   jq \
-  libffi-dev=3.2.1-8 \
-  libghc-postgresql-libpq-dev=0.9.3.1-1 \
-  libgmp-dev=2:6.1.2+dfsg-2 \
-  libncursesw5=6.1-1ubuntu1.18.04 \
-  libpq-dev=10.14-0ubuntu0.18.04.1 \
-  libssl-dev=1.1.1-1ubuntu2.1~18.04.6 \
-  libsystemd-dev=237-3ubuntu10.42 \
-  libtinfo-dev=6.1-1ubuntu1.18.04 \
-  libtool=2.4.6-2 \
+  libffi-dev=3.3-4 \
+  libghc-postgresql-libpq-dev=0.9.4.2-1build1 \
+  libgmp-dev=2:6.2.0+dfsg-4 \
+  libncursesw5=6.2-0ubuntu2 \
+  libpq-dev=12.4-0ubuntu0.20.04.1 \
+  libssl-dev=1.1.1f-1ubuntu2 \
+  libsystemd-dev=245.4-4ubuntu3.2 \
+  libtinfo-dev=6.2-0ubuntu2 \
+  libtool=2.4.6-14 \
   make \
   pkg-config \
   tmux \
   wget \
-  zlib1g-dev=1:1.2.11.dfsg-0ubuntu2
+  zlib1g-dev=1:1.2.11.dfsg-2ubuntu1
 RUN wget --secure-protocol=TLSv1_2 \
   https://downloads.haskell.org/~cabal/cabal-install-${CABAL_VERSION}/cabal-install-${CABAL_VERSION}-x86_64-unknown-linux.tar.xz &&\
   tar -xf cabal-install-${CABAL_VERSION}-x86_64-unknown-linux.tar.xz &&\


### PR DESCRIPTION
# Description
This reverts commit d92b65e8 as 20.04 is now supported