### PR TITLE
Feat/198 construction derive staking support

### DIFF
--- a/cardano-rosetta-server/src/server/controllers/construction-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/construction-controller.ts
@@ -12,7 +12,7 @@ import {
 import { ErrorFactory } from '../utils/errors';
 import { withNetworkValidation } from './controllers-helper';
 import { CardanoCli } from '../utils/cardanonode-cli';
-import { UTxOAddressType } from '../utils/constants';
+import { AddressType } from '../utils/constants';
 
 export interface ConstructionController {
   constructionDerive(
@@ -104,7 +104,7 @@ const configure = (
           publicKey.hex_bytes,
           // eslint-disable-next-line camelcase
           stakingCredential?.hex_bytes,
-          addressType as UTxOAddressType
+          addressType as AddressType
         );
         if (!address) {
           logger.error('[constructionDerive] There was an error generating address');

--- a/cardano-rosetta-server/src/server/controllers/construction-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/construction-controller.ts
@@ -12,6 +12,7 @@ import {
 import { ErrorFactory } from '../utils/errors';
 import { withNetworkValidation } from './controllers-helper';
 import { CardanoCli } from '../utils/cardanonode-cli';
+import { UTxOAddressType } from '../utils/constants';
 
 export interface ConstructionController {
   constructionDerive(
@@ -101,9 +102,9 @@ const configure = (
           logger,
           networkIdentifier,
           publicKey.hex_bytes,
-          addressType,
           // eslint-disable-next-line camelcase
-          stakingCredential?.hex_bytes
+          stakingCredential?.hex_bytes,
+          addressType as UTxOAddressType
         );
         if (!address) {
           logger.error('[constructionDerive] There was an error generating address');

--- a/cardano-rosetta-server/src/server/controllers/construction-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/construction-controller.ts
@@ -81,7 +81,7 @@ const configure = (
           logger.info('[constructionDerive] About to check if staking credential has valid length and curve type');
           if (!isKeyValid(stakingCredential.hex_bytes, stakingCredential.curve_type)) {
             logger.info('[constructionDerive] Staking credential has an invalid format');
-            throw ErrorFactory.invalidPublicKeyFormat();
+            throw ErrorFactory.invalidStakingKeyFormat();
           }
           logger.info('[constructionDerive] Staking credential key has a valid format');
         }

--- a/cardano-rosetta-server/src/server/controllers/construction-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/construction-controller.ts
@@ -97,7 +97,14 @@ const configure = (
         }
 
         logger.info(request.body, '[constructionDerive] About to generate address');
-        const address = cardanoService.generateAddress(logger, networkIdentifier, publicKey.hex_bytes);
+        const address = cardanoService.generateAddress(
+          logger,
+          networkIdentifier,
+          publicKey.hex_bytes,
+          addressType,
+          // eslint-disable-next-line camelcase
+          stakingCredential?.hex_bytes
+        );
         if (!address) {
           logger.error('[constructionDerive] There was an error generating address');
           throw ErrorFactory.addressGenerationError();

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1469,14 +1469,16 @@
           "public_key": {
             "$ref": "#/components/schemas/PublicKey"
           },
-          "staking_credential": {
-            "$ref": "#/components/schemas/PublicKey"
-          },
-          "address_type": {
-            "$ref": "#/components/schemas/AddressType"
-          },
           "metadata": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+              "staking_credential": {
+                "$ref": "#/components/schemas/PublicKey"
+              },
+              "address_type": {
+                "$ref": "#/components/schemas/AddressType"
+              }
+            }
           }
         }
       },

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1079,8 +1079,7 @@
       },
       "AddressType": {
         "description": "AddressType is the type of UTxO address. * Base address - associated to a payment and a staking credential * Enterprise address - holds no delegation rights and will be created when no stake key is sent to the API",
-        "type": "string",
-        "enum": ["Enterprise", "Base", "Reward"]
+        "type": "string"
       },
       "PublicKey": {
         "description": "PublicKey contains a public key byte array for a particular CurveType encoded in hex. Note that there is no PrivateKey struct as this is NEVER the concern of an implementation.",

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1078,7 +1078,7 @@
         "example": 1582833600000
       },
       "AddressType": {
-        "description": "AddressType is the type of UTxO address. * Base address - associated to a payment and a staking credential * Enterprise address - holds no delegation rights and will be created when no stake key is sent to the API",
+        "description": "* Base address - associated to a payment and a staking credential, * Reward address - associated to a staking credential * Enterprise address - holds no delegation rights and will be created when no stake key is sent to the API",
         "type": "string"
       },
       "PublicKey": {

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1077,6 +1077,11 @@
         "minimum": 0,
         "example": 1582833600000
       },
+      "AddressType": {
+        "description": "AddressType is the type of UTxO address. * Base address - associated to a payment and a staking credential * Enterprise address - holds no delegation rights and will be created when no stake key is sent to the API",
+        "type": "string",
+        "enum": ["Enterprise", "Base", "Reward"]
+      },
       "PublicKey": {
         "description": "PublicKey contains a public key byte array for a particular CurveType encoded in hex. Note that there is no PrivateKey struct as this is NEVER the concern of an implementation.",
         "type": "object",
@@ -1463,6 +1468,12 @@
           },
           "public_key": {
             "$ref": "#/components/schemas/PublicKey"
+          },
+          "staking_credential": {
+            "$ref": "#/components/schemas/PublicKey"
+          },
+          "address_type": {
+            "$ref": "#/components/schemas/AddressType"
           },
           "metadata": {
             "type": "object"

--- a/cardano-rosetta-server/src/server/services/cardano-services.ts
+++ b/cardano-rosetta-server/src/server/services/cardano-services.ts
@@ -161,6 +161,7 @@ const calculateFee = (inputs: Components.Schemas.Operation[], outputs: Component
 const getAddressPrefix = (network: number) =>
   network === NetworkIdentifier.CARDANO_MAINNET_NETWORK ? 'addr' : 'addr_test';
 
+// Prefix according to: https://github.com/cardano-foundation/CIPs/tree/master/CIP5#specification
 const getStakeAddressPrefix = (network: number) =>
   network === NetworkIdentifier.CARDANO_MAINNET_NETWORK ? 'stake' : 'stake_test';
 

--- a/cardano-rosetta-server/src/server/services/cardano-services.ts
+++ b/cardano-rosetta-server/src/server/services/cardano-services.ts
@@ -159,6 +159,9 @@ const calculateFee = (inputs: Components.Schemas.Operation[], outputs: Component
 const getAddressPrefix = (network: number) =>
   network === NetworkIdentifier.CARDANO_MAINNET_NETWORK ? 'addr' : 'addr_test';
 
+const getStakeAddressPrefix = (network: number) =>
+  network === NetworkIdentifier.CARDANO_MAINNET_NETWORK ? 'stake' : 'stake_test';
+
 const parseInputToOperation = (input: CardanoWasm.TransactionInput, index: number): Components.Schemas.Operation => ({
   operation_identifier: { index },
   coin_change: {
@@ -333,7 +336,7 @@ const configure = (linearFeeParameters: LinearFeeParameters): CardanoService => 
     if (type === UTxOAddressTypes.REWARD) {
       logger.info('[generateAddress] Deriving cardano enterprise address from valid public staking key');
       const rewardAddress = CardanoWasm.RewardAddress.new(network, payment);
-      const bech32address = rewardAddress.to_address().to_bech32(getAddressPrefix(network));
+      const bech32address = rewardAddress.to_address().to_bech32(getStakeAddressPrefix(network));
       logger.info(`[generateAddress] reward address is ${bech32address}`);
       return bech32address;
     }

--- a/cardano-rosetta-server/src/server/services/cardano-services.ts
+++ b/cardano-rosetta-server/src/server/services/cardano-services.ts
@@ -4,7 +4,7 @@ import cbor from 'cbor';
 import { Logger } from 'fastify';
 import { ErrorFactory } from '../utils/errors';
 import { hexFormatter } from '../utils/formatters';
-import { ADA, ADA_DECIMALS, operationType } from '../utils/constants';
+import { ADA, ADA_DECIMALS, operationType, UTxOAddressTypes } from '../utils/constants';
 
 // Nibbles
 export const SIGNATURE_LENGTH = 128;
@@ -314,12 +314,6 @@ const getWitnessesForTransaction = (logger: Logger, signatures: Signatures[]): C
 };
 
 const getUniqueAddresses = (addresses: string[]) => [...new Set(addresses)];
-
-enum UTxOAddressTypes {
-  ENTERPRISE = 'Enterprise',
-  BASE = 'Base',
-  REWARD = 'Reward'
-}
 
 const configure = (linearFeeParameters: LinearFeeParameters): CardanoService => ({
   generateAddress(logger, network, publicKey, type, stakingCredential) {

--- a/cardano-rosetta-server/src/server/utils/constants.ts
+++ b/cardano-rosetta-server/src/server/utils/constants.ts
@@ -30,7 +30,7 @@ export const SUCCESS_OPERATION_STATE = {
   successful: true
 };
 
-export enum UTxOAddressType {
+export enum AddressType {
   ENTERPRISE = 'Enterprise',
   BASE = 'Base',
   REWARD = 'Reward'

--- a/cardano-rosetta-server/src/server/utils/constants.ts
+++ b/cardano-rosetta-server/src/server/utils/constants.ts
@@ -29,3 +29,9 @@ export const SUCCESS_OPERATION_STATE = {
   status: operationTypeStatus.SUCCESS,
   successful: true
 };
+
+export enum UTxOAddressTypes {
+  ENTERPRISE = 'Enterprise',
+  BASE = 'Base',
+  REWARD = 'Reward'
+}

--- a/cardano-rosetta-server/src/server/utils/constants.ts
+++ b/cardano-rosetta-server/src/server/utils/constants.ts
@@ -30,7 +30,7 @@ export const SUCCESS_OPERATION_STATE = {
   successful: true
 };
 
-export enum UTxOAddressTypes {
+export enum UTxOAddressType {
   ENTERPRISE = 'Enterprise',
   BASE = 'Base',
   REWARD = 'Reward'

--- a/cardano-rosetta-server/src/server/utils/errors.ts
+++ b/cardano-rosetta-server/src/server/utils/errors.ts
@@ -60,6 +60,7 @@ export const Errors = {
     message: 'Provided address type is invalid',
     code: 4016
   },
+  INVALID_STAKING_KEY_FORMAT: { message: 'Invalid staking key format', code: 4017 },
   UNSPECIFIED_ERROR: { message: 'An error occurred', code: 5000 },
   NOT_IMPLEMENTED: { message: 'Not implemented', code: 5001 },
   ADDRESS_GENERATION_ERROR: { message: 'Address generation error', code: 5002 },
@@ -90,6 +91,7 @@ const genesisBlockNotFound: CreateErrorFunction = () => buildApiError(Errors.GEN
 const transactionNotFound: CreateErrorFunction = () => buildApiError(Errors.TRANSACTION_NOT_FOUND, false);
 const addressGenerationError: CreateErrorFunction = () => buildApiError(Errors.ADDRESS_GENERATION_ERROR, false);
 const invalidPublicKeyFormat: CreateErrorFunction = () => buildApiError(Errors.INVALID_PUBLIC_KEY_FORMAT, false);
+const invalidStakingKeyFormat: CreateErrorFunction = () => buildApiError(Errors.INVALID_STAKING_KEY_FORMAT, false);
 const parseSignedTransactionError: CreateErrorFunction = () =>
   buildApiError(Errors.PARSE_SIGNED_TRANSACTION_ERROR, false);
 const cantBuildWitnessesSet: CreateErrorFunction = () => buildApiError(Errors.CANT_BUILD_WITNESSES_SET, false);
@@ -124,6 +126,7 @@ export const ErrorFactory = {
   transactionNotFound,
   addressGenerationError,
   invalidPublicKeyFormat,
+  invalidStakingKeyFormat,
   parseSignedTransactionError,
   cantBuildSignedTransaction,
   cantBuildWitnessesSet,

--- a/cardano-rosetta-server/src/server/utils/errors.ts
+++ b/cardano-rosetta-server/src/server/utils/errors.ts
@@ -56,6 +56,10 @@ export const Errors = {
     message: 'Provided address is invalid',
     code: 4015
   },
+  INVALID_ADDRESS_TYPE: {
+    message: 'Provided address type is invalid',
+    code: 4016
+  },
   UNSPECIFIED_ERROR: { message: 'An error occurred', code: 5000 },
   NOT_IMPLEMENTED: { message: 'Not implemented', code: 5001 },
   ADDRESS_GENERATION_ERROR: { message: 'Address generation error', code: 5002 },
@@ -107,6 +111,7 @@ const transactionInputDeserializationError: CreateErrorFunction = (details?: str
 const transactionOutputDeserializationError: CreateErrorFunction = (details?: string) =>
   buildApiError(Errors.TRANSACTION_OUTPUT_DESERIALIZATION_ERROR, false, details);
 const invalidAddressError: CreateErrorFunction = address => buildApiError(Errors.INVALID_ADDRESS, true, address);
+const invalidAddressTypeError: CreateErrorFunction = type => buildApiError(Errors.INVALID_ADDRESS_TYPE, true, type);
 
 export const ErrorFactory = {
   blockNotFoundError,
@@ -130,7 +135,8 @@ export const ErrorFactory = {
   sendTransactionError,
   transactionInputDeserializationError,
   transactionOutputDeserializationError,
-  invalidAddressError
+  invalidAddressError,
+  invalidAddressTypeError
 };
 
 export const configNotFoundError: CreateServerErrorFunction = () =>

--- a/cardano-rosetta-server/src/server/utils/errors.ts
+++ b/cardano-rosetta-server/src/server/utils/errors.ts
@@ -61,6 +61,7 @@ export const Errors = {
     code: 4016
   },
   INVALID_STAKING_KEY_FORMAT: { message: 'Invalid staking key format', code: 4017 },
+  STAKING_KEY_MISSING: { message: 'Staking key is required for this type of address', code: 4018 },
   UNSPECIFIED_ERROR: { message: 'An error occurred', code: 5000 },
   NOT_IMPLEMENTED: { message: 'Not implemented', code: 5001 },
   ADDRESS_GENERATION_ERROR: { message: 'Address generation error', code: 5002 },
@@ -92,6 +93,7 @@ const transactionNotFound: CreateErrorFunction = () => buildApiError(Errors.TRAN
 const addressGenerationError: CreateErrorFunction = () => buildApiError(Errors.ADDRESS_GENERATION_ERROR, false);
 const invalidPublicKeyFormat: CreateErrorFunction = () => buildApiError(Errors.INVALID_PUBLIC_KEY_FORMAT, false);
 const invalidStakingKeyFormat: CreateErrorFunction = () => buildApiError(Errors.INVALID_STAKING_KEY_FORMAT, false);
+const missingStakingKeyError: CreateErrorFunction = type => buildApiError(Errors.STAKING_KEY_MISSING, false, type);
 const parseSignedTransactionError: CreateErrorFunction = () =>
   buildApiError(Errors.PARSE_SIGNED_TRANSACTION_ERROR, false);
 const cantBuildWitnessesSet: CreateErrorFunction = () => buildApiError(Errors.CANT_BUILD_WITNESSES_SET, false);
@@ -127,6 +129,7 @@ export const ErrorFactory = {
   addressGenerationError,
   invalidPublicKeyFormat,
   invalidStakingKeyFormat,
+  missingStakingKeyError,
   parseSignedTransactionError,
   cantBuildSignedTransaction,
   cantBuildWitnessesSet,

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -49,7 +49,7 @@ declare namespace Components {
     /**
      * AddressType is the type of UTxO address. * Base address - associated to a payment and a staking credential * Enterprise address - holds no delegation rights and will be created when no stake key is sent to the API
      */
-    export type AddressType = 'Enterprise' | 'Base' | 'Reward';
+    export type AddressType = string;
     /**
      * Allow specifies supported Operation status, Operation types, and all possible error statuses. This Allow object is used by clients to validate the correctness of a Rosetta Server implementation. It is expected that these clients will error if they receive some response that contains any of the above information that is not specified here.
      */

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -216,9 +216,10 @@ declare namespace Components {
     export interface ConstructionDeriveRequest {
       network_identifier: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
       public_key: /* PublicKey contains a public key byte array for a particular CurveType encoded in hex. Note that there is no PrivateKey struct as this is NEVER the concern of an implementation. */ PublicKey;
-      staking_credential?: /* PublicKey contains a public key byte array for a particular CurveType encoded in hex. Note that there is no PrivateKey struct as this is NEVER the concern of an implementation. */ PublicKey;
-      address_type?: /* AddressType is the type of UTxO address. * Base address - associated to a payment and a staking credential * Enterprise address - holds no delegation rights and will be created when no stake key is sent to the API */ AddressType;
-      metadata?: {};
+      metadata?: {
+        staking_credential?: /* PublicKey contains a public key byte array for a particular CurveType encoded in hex. Note that there is no PrivateKey struct as this is NEVER the concern of an implementation. */ PublicKey;
+        address_type?: /* AddressType is the type of UTxO address. * Base address - associated to a payment and a staking credential * Enterprise address - holds no delegation rights and will be created when no stake key is sent to the API */ AddressType;
+      };
     }
     /**
      * ConstructionDeriveResponse is returned by the `/construction/derive` endpoint.

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -47,7 +47,7 @@ declare namespace Components {
       metadata?: {};
     }
     /**
-     * AddressType is the type of UTxO address. * Base address - associated to a payment and a staking credential * Enterprise address - holds no delegation rights and will be created when no stake key is sent to the API
+     * * Base address - associated to a payment and a staking credential, * Reward address - associated to a staking credential * Enterprise address - holds no delegation rights and will be created when no stake key is sent to the API
      */
     export type AddressType = string;
     /**
@@ -218,7 +218,7 @@ declare namespace Components {
       public_key: /* PublicKey contains a public key byte array for a particular CurveType encoded in hex. Note that there is no PrivateKey struct as this is NEVER the concern of an implementation. */ PublicKey;
       metadata?: {
         staking_credential?: /* PublicKey contains a public key byte array for a particular CurveType encoded in hex. Note that there is no PrivateKey struct as this is NEVER the concern of an implementation. */ PublicKey;
-        address_type?: /* AddressType is the type of UTxO address. * Base address - associated to a payment and a staking credential * Enterprise address - holds no delegation rights and will be created when no stake key is sent to the API */ AddressType;
+        address_type?: /* * Base address - associated to a payment and a staking credential, * Reward address - associated to a staking credential * Enterprise address - holds no delegation rights and will be created when no stake key is sent to the API */ AddressType;
       };
     }
     /**

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -47,6 +47,10 @@ declare namespace Components {
       metadata?: {};
     }
     /**
+     * AddressType is the type of UTxO address. * Base address - associated to a payment and a staking credential * Enterprise address - holds no delegation rights and will be created when no stake key is sent to the API
+     */
+    export type AddressType = 'Enterprise' | 'Base' | 'Reward';
+    /**
      * Allow specifies supported Operation status, Operation types, and all possible error statuses. This Allow object is used by clients to validate the correctness of a Rosetta Server implementation. It is expected that these clients will error if they receive some response that contains any of the above information that is not specified here.
      */
     export interface Allow {
@@ -212,6 +216,8 @@ declare namespace Components {
     export interface ConstructionDeriveRequest {
       network_identifier: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
       public_key: /* PublicKey contains a public key byte array for a particular CurveType encoded in hex. Note that there is no PrivateKey struct as this is NEVER the concern of an implementation. */ PublicKey;
+      staking_credential?: /* PublicKey contains a public key byte array for a particular CurveType encoded in hex. Note that there is no PrivateKey struct as this is NEVER the concern of an implementation. */ PublicKey;
+      address_type?: /* AddressType is the type of UTxO address. * Base address - associated to a payment and a staking credential * Enterprise address - holds no delegation rights and will be created when no stake key is sent to the API */ AddressType;
       metadata?: {};
     }
     /**

--- a/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
@@ -7,6 +7,7 @@ import { setupDatabase, setupServer, testInvalidNetworkParameters } from '../uti
 const CONSTRUCTION_DERIVE_ENDPOINT = '/construction/derive';
 const INVALID_PUBLIC_KEY_FORMAT = 'Invalid public key format';
 const INVALID_STAKING_KEY_FORMAT = 'Invalid staking key format';
+const STAKING_KEY_MISSING = 'Staking key is required for this type of address';
 const INVALID_ADDRESS_TYPE = 'Provided address type is invalid';
 
 type PublicKey = {
@@ -199,6 +200,21 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
     expect(response.json().address).toEqual(
       'addr1q9dhy809valxaer3nlvg2h5nudd62pxp6lu0cs36zczhfr98y6pah6lvppk8xft57nef6yexqh6rr204yemcmm3emhzsgg4fg0'
     );
+  });
+
+  test('Should return an error when the address type is Base but no staking credentials are provided', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_DERIVE_ENDPOINT,
+      payload: generatePayload({
+        blockchain: 'cardano',
+        network: 'mainnet',
+        type: 'Base',
+        key: '159abeeecdf167ccc0ea60b30f9522154a0d74161aeb159fb43b6b0695f057b3'
+      })
+    });
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({ code: 4018, message: STAKING_KEY_MISSING, retriable: false });
   });
 
   // eslint-disable-next-line max-len

--- a/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
@@ -211,7 +211,7 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
       })
     });
     expect(response.statusCode).toEqual(StatusCodes.OK);
-    expect(response.json().address).toEqual('addr1uxnjdq7ma0kqsmrny460fu5azvnqtap3486jvaudacuam3ghuwnnw');
+    expect(response.json().address).toEqual('stake1uxnjdq7ma0kqsmrny460fu5azvnqtap3486jvaudacuam3g3yc4nu');
   });
 
   test('Should return an error when the staking key has a lower length than 32', async () => {

--- a/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
@@ -7,14 +7,53 @@ import { setupDatabase, setupServer, testInvalidNetworkParameters } from '../uti
 const CONSTRUCTION_DERIVE_ENDPOINT = '/construction/derive';
 const INVALID_PUBLIC_KEY_FORMAT = 'Invalid public key format';
 
+type PublicKey = {
+  hex_bytes: string;
+  curve_type: string;
+};
+
+type DeriveMetadata = {
+  staking_credential?: PublicKey;
+  address_type?: string;
+};
+
+const generateMetadata = (addressType?: string, stakingKey?: string, curveType?: string): DeriveMetadata => {
+  const metadata: DeriveMetadata = {};
+  if (addressType) metadata.address_type = addressType;
+  if (stakingKey)
+    metadata.staking_credential = {
+      hex_bytes: stakingKey,
+      curve_type: curveType || 'edwards25519'
+    };
+  return metadata;
+};
+
 type GeneratePayloadInput = {
   blockchain: string;
   network: string;
   key?: string;
   curveType?: string;
+  type?: string;
+  stakingKey?: string;
 };
 
-const generatePayload = ({ blockchain, network, key, curveType }: GeneratePayloadInput) => ({
+type DerivePayload = {
+  network_identifier: {
+    blockchain: string;
+    network: string;
+  };
+  public_key: PublicKey;
+  metadata?: DeriveMetadata;
+};
+
+const generatePayload = ({
+  blockchain,
+  network,
+  key,
+  curveType,
+  type,
+  stakingKey
+}: GeneratePayloadInput): DerivePayload => ({
   network_identifier: {
     blockchain,
     network
@@ -22,7 +61,8 @@ const generatePayload = ({ blockchain, network, key, curveType }: GeneratePayloa
   public_key: {
     hex_bytes: key || '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
     curve_type: curveType || 'edwards25519'
-  }
+  },
+  metadata: generateMetadata(type, stakingKey, curveType)
 });
 
 describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
@@ -102,6 +142,21 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
         blockchain: 'cardano',
         network: 'mainnet',
         key: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F__'
+      })
+    });
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({ code: 4007, message: INVALID_PUBLIC_KEY_FORMAT, retriable: false });
+  });
+
+  test('Should return an error when the staking key has an invalid format', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_DERIVE_ENDPOINT,
+      payload: generatePayload({
+        blockchain: 'cardano',
+        network: 'mainnet',
+        type: 'Enterprise',
+        stakingKey: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F__'
       })
     });
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);

--- a/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
@@ -6,6 +6,7 @@ import { setupDatabase, setupServer, testInvalidNetworkParameters } from '../uti
 
 const CONSTRUCTION_DERIVE_ENDPOINT = '/construction/derive';
 const INVALID_PUBLIC_KEY_FORMAT = 'Invalid public key format';
+const INVALID_ADDRESS_TYPE = 'Provided address type is invalid';
 
 type PublicKey = {
   hex_bytes: string;
@@ -161,5 +162,20 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
     });
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
     expect(response.json()).toEqual({ code: 4007, message: INVALID_PUBLIC_KEY_FORMAT, retriable: false });
+  });
+
+  test('Should return an error when the address type has an invalid value', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_DERIVE_ENDPOINT,
+      payload: generatePayload({
+        blockchain: 'cardano',
+        network: 'mainnet',
+        type: 'Invalid',
+        stakingKey: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F'
+      })
+    });
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({ code: 4016, message: INVALID_ADDRESS_TYPE, retriable: true });
   });
 });

--- a/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
@@ -213,4 +213,28 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
     expect(response.statusCode).toEqual(StatusCodes.OK);
     expect(response.json().address).toEqual('addr1uxnjdq7ma0kqsmrny460fu5azvnqtap3486jvaudacuam3ghuwnnw');
   });
+
+  test('Should return an error when the staking key has a lower length than 32', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_DERIVE_ENDPOINT,
+      payload: generatePayload({ blockchain: 'cardano', network: 'mainnet', stakingKey: 'smallPublicKey' })
+    });
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({ code: 4007, message: INVALID_PUBLIC_KEY_FORMAT, retriable: false });
+  });
+
+  test('Should return an error when the staking key has a bigger length than 32', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_DERIVE_ENDPOINT,
+      payload: generatePayload({
+        blockchain: 'cardano',
+        network: 'mainnet',
+        stakingKey: 'ThisIsABiggerPublicKeyForTestingPurposesThisIsABiggerPublicKeyForTestingPurposes'
+      })
+    });
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({ code: 4007, message: INVALID_PUBLIC_KEY_FORMAT, retriable: false });
+  });
 });

--- a/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
@@ -7,7 +7,14 @@ import { setupDatabase, setupServer, testInvalidNetworkParameters } from '../uti
 const CONSTRUCTION_DERIVE_ENDPOINT = '/construction/derive';
 const INVALID_PUBLIC_KEY_FORMAT = 'Invalid public key format';
 
-const generatePayload = (blockchain: string, network: string, key?: string, curveType?: string) => ({
+type GeneratePayloadInput = {
+  blockchain: string;
+  network: string;
+  key?: string;
+  curveType?: string;
+};
+
+const generatePayload = ({ blockchain, network, key, curveType }: GeneratePayloadInput) => ({
   network_identifier: {
     blockchain,
     network
@@ -36,7 +43,7 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
     const response = await server.inject({
       method: 'post',
       url: CONSTRUCTION_DERIVE_ENDPOINT,
-      payload: generatePayload('cardano', 'mainnet')
+      payload: generatePayload({ blockchain: 'cardano', network: 'mainnet' })
     });
     expect(response.statusCode).toEqual(StatusCodes.OK);
     expect(response.json().address).toEqual('addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx');
@@ -46,7 +53,7 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
     const response = await server.inject({
       method: 'post',
       url: CONSTRUCTION_DERIVE_ENDPOINT,
-      payload: generatePayload('cardano', 'mainnet', 'smallPublicKey')
+      payload: generatePayload({ blockchain: 'cardano', network: 'mainnet', key: 'smallPublicKey' })
     });
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
     expect(response.json()).toEqual({ code: 4007, message: INVALID_PUBLIC_KEY_FORMAT, retriable: false });
@@ -56,11 +63,11 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
     const response = await server.inject({
       method: 'post',
       url: CONSTRUCTION_DERIVE_ENDPOINT,
-      payload: generatePayload(
-        'cardano',
-        'mainnet',
-        'ThisIsABiggerPublicKeyForTestingPurposesThisIsABiggerPublicKeyForTestingPurposes'
-      )
+      payload: generatePayload({
+        blockchain: 'cardano',
+        network: 'mainnet',
+        key: 'ThisIsABiggerPublicKeyForTestingPurposesThisIsABiggerPublicKeyForTestingPurposes'
+      })
     });
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
     expect(response.json()).toEqual({ code: 4007, message: INVALID_PUBLIC_KEY_FORMAT, retriable: false });
@@ -68,7 +75,7 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
 
   testInvalidNetworkParameters(
     CONSTRUCTION_DERIVE_ENDPOINT,
-    (blockchain, network) => generatePayload(blockchain, network),
+    (blockchain, network) => generatePayload({ blockchain, network }),
     () => server
   );
 
@@ -76,12 +83,12 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
     const response = await server.inject({
       method: 'post',
       url: CONSTRUCTION_DERIVE_ENDPOINT,
-      payload: generatePayload(
-        'cardano',
-        'mainnet',
-        '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
-        'secp256k1'
-      )
+      payload: generatePayload({
+        blockchain: 'cardano',
+        network: 'mainnet',
+        key: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
+        curveType: 'secp256k1'
+      })
     });
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
     expect(response.json()).toEqual({ code: 4007, message: INVALID_PUBLIC_KEY_FORMAT, retriable: false });
@@ -91,11 +98,11 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
     const response = await server.inject({
       method: 'post',
       url: CONSTRUCTION_DERIVE_ENDPOINT,
-      payload: generatePayload(
-        'cardano',
-        'mainnet',
-        '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F__.'
-      )
+      payload: generatePayload({
+        blockchain: 'cardano',
+        network: 'mainnet',
+        key: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F__'
+      })
     });
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
     expect(response.json()).toEqual({ code: 4007, message: INVALID_PUBLIC_KEY_FORMAT, retriable: false });

--- a/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
@@ -178,4 +178,39 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
     expect(response.json()).toEqual({ code: 4016, message: INVALID_ADDRESS_TYPE, retriable: true });
   });
+
+  // eslint-disable-next-line max-len
+  test('Should return the Base address corresponding to the public key, staking key and mainnet network when providing valid keys', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_DERIVE_ENDPOINT,
+      payload: generatePayload({
+        blockchain: 'cardano',
+        network: 'mainnet',
+        type: 'Base',
+        key: '159abeeecdf167ccc0ea60b30f9522154a0d74161aeb159fb43b6b0695f057b3',
+        stakingKey: '964774728c8306a42252adbfb07ccd6ef42399f427ade25a5933ce190c5a8760'
+      })
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json().address).toEqual(
+      'addr1q9dhy809valxaer3nlvg2h5nudd62pxp6lu0cs36zczhfr98y6pah6lvppk8xft57nef6yexqh6rr204yemcmm3emhzsgg4fg0'
+    );
+  });
+
+  // eslint-disable-next-line max-len
+  test('Should return the Reward address corresponding to the public key and mainnet network when providing a valid public key', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_DERIVE_ENDPOINT,
+      payload: generatePayload({
+        blockchain: 'cardano',
+        network: 'mainnet',
+        type: 'Reward',
+        key: '964774728c8306a42252adbfb07ccd6ef42399f427ade25a5933ce190c5a8760'
+      })
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json().address).toEqual('addr1uxnjdq7ma0kqsmrny460fu5azvnqtap3486jvaudacuam3ghuwnnw');
+  });
 });

--- a/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
@@ -6,6 +6,7 @@ import { setupDatabase, setupServer, testInvalidNetworkParameters } from '../uti
 
 const CONSTRUCTION_DERIVE_ENDPOINT = '/construction/derive';
 const INVALID_PUBLIC_KEY_FORMAT = 'Invalid public key format';
+const INVALID_STAKING_KEY_FORMAT = 'Invalid staking key format';
 const INVALID_ADDRESS_TYPE = 'Provided address type is invalid';
 
 type PublicKey = {
@@ -161,7 +162,7 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
       })
     });
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
-    expect(response.json()).toEqual({ code: 4007, message: INVALID_PUBLIC_KEY_FORMAT, retriable: false });
+    expect(response.json()).toEqual({ code: 4017, message: INVALID_STAKING_KEY_FORMAT, retriable: false });
   });
 
   test('Should return an error when the address type has an invalid value', async () => {
@@ -224,7 +225,7 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
       payload: generatePayload({ blockchain: 'cardano', network: 'mainnet', stakingKey: 'smallPublicKey' })
     });
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
-    expect(response.json()).toEqual({ code: 4007, message: INVALID_PUBLIC_KEY_FORMAT, retriable: false });
+    expect(response.json()).toEqual({ code: 4017, message: INVALID_STAKING_KEY_FORMAT, retriable: false });
   });
 
   test('Should return an error when the staking key has a bigger length than 32', async () => {
@@ -238,6 +239,6 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
       })
     });
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
-    expect(response.json()).toEqual({ code: 4007, message: INVALID_PUBLIC_KEY_FORMAT, retriable: false });
+    expect(response.json()).toEqual({ code: 4017, message: INVALID_STAKING_KEY_FORMAT, retriable: false });
   });
 });

--- a/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
@@ -193,6 +193,8 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
       })
     });
     expect(response.statusCode).toEqual(StatusCodes.OK);
+    // Address generated locally with following command (using private keys attached to issue #198):
+    // cat addr.prv | ./cardano-address key public | ./cardano-address address payment  --network-tag 1 | ./cardano-address address delegation $(cat stake.prv | ./cardano-address key public)
     expect(response.json().address).toEqual(
       'addr1q9dhy809valxaer3nlvg2h5nudd62pxp6lu0cs36zczhfr98y6pah6lvppk8xft57nef6yexqh6rr204yemcmm3emhzsgg4fg0'
     );
@@ -211,6 +213,7 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
       })
     });
     expect(response.statusCode).toEqual(StatusCodes.OK);
+    // https://cardanoscan.io/address/015b721de5677e6ee4719fd8855e93e35ba504c1d7f8fc423a1605748ca72683dbebec086c732574f4f29d132605f431a9f526778dee39ddc5
     expect(response.json().address).toEqual('stake1uxnjdq7ma0kqsmrny460fu5azvnqtap3486jvaudacuam3g3yc4nu');
   });
 

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -82,6 +82,7 @@ const allow = {
       message: 'Provided address type is invalid',
       retriable: true
     },
+    { code: 4017, message: 'Invalid staking key format', retriable: false },
     {
       code: 5000,
       message: 'An error occurred',

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -83,6 +83,7 @@ const allow = {
       retriable: true
     },
     { code: 4017, message: 'Invalid staking key format', retriable: false },
+    { code: 4018, message: 'Staking key is required for this type of address', retriable: false },
     {
       code: 5000,
       message: 'An error occurred',

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -78,6 +78,11 @@ const allow = {
       retriable: true
     },
     {
+      code: 4016,
+      message: 'Provided address type is invalid',
+      retriable: true
+    },
+    {
       code: 5000,
       message: 'An error occurred',
       retriable: true

--- a/cardano-rosetta-server/test/unit/services/cardano-services.test.ts
+++ b/cardano-rosetta-server/test/unit/services/cardano-services.test.ts
@@ -1,4 +1,4 @@
-import configure, { AddressType, CardanoService } from '../../../src/server/services/cardano-services';
+import configure, { EraAddressType, CardanoService } from '../../../src/server/services/cardano-services';
 
 describe('Cardano Service', () => {
   let cardanoService: CardanoService;
@@ -9,26 +9,28 @@ describe('Cardano Service', () => {
 
   describe('Address type detection', () => {
     it('Should detect a valid bech32 Shelley mainnet address', () => {
-      const addressType = cardanoService.getAddressType(
+      const addressType = cardanoService.getEraAddressType(
         'addr1q9ccruvttlfsqwu47ndmapxmk5xa8cc9ngsgj90290tfpysc6gcpmq6ejwgewr49ja0kghws4fdy9t2zecvd7zwqrheqjze0c7'
       );
-      expect(addressType).toBe(AddressType.Shelley);
+      expect(addressType).toBe(EraAddressType.Shelley);
     });
 
     it('Should properly detect a valid bech32 Shelley testnet address', () => {
-      const addressType = cardanoService.getAddressType(
+      const addressType = cardanoService.getEraAddressType(
         'addr_test1vru64wlzn85v7fecg0mz33lh00wlggqtquvzzuhf6vusyes32jz9w'
       );
-      expect(addressType).toBe(AddressType.Shelley);
+      expect(addressType).toBe(EraAddressType.Shelley);
     });
 
     it('Should detect a valid Byron address', () => {
-      const addressType = cardanoService.getAddressType('Ae2tdPwUPEYzjqSKk2YfU2ZZxdjDkMvn294ASnBNaFRmv4KX7zng7ZDTCEU');
-      expect(addressType).toBe(AddressType.Byron);
+      const addressType = cardanoService.getEraAddressType(
+        'Ae2tdPwUPEYzjqSKk2YfU2ZZxdjDkMvn294ASnBNaFRmv4KX7zng7ZDTCEU'
+      );
+      expect(addressType).toBe(EraAddressType.Byron);
     });
 
     it('Should return null if address is wrong', () => {
-      const addressType = cardanoService.getAddressType('WRONG');
+      const addressType = cardanoService.getEraAddressType('WRONG');
       expect(addressType).toBe(null);
     });
   });


### PR DESCRIPTION
# Description

Endpoint `/construction/derive` now supports the creation of Base and Reward addresses besided the already supported Enterprise address.

# Proposed Solution

The staking key and the address type are provided as optional parameters in the metadata.

The controller does some basic validation and the service does the actual construction based on the following:

- _Base address_: if address type is 'Base' and both the public key and the staking keys are provided.
- _Reward address_: if address type is 'Reward' (the required public key is the only needed).
- _Enterprise address_: if address type is 'Enterprise' or no type at all (default scenario).

# References

Closes #198 
