### PR TITLE
fix: there were missing some staking network operations

### DIFF
--- a/cardano-rosetta-server/src/server/controllers/network-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/network-controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from 'fastify';
 import { NetworkService } from '../services/network-service';
-import { MIDDLEWARE_VERSION, operationType, ROSETTA_VERSION, SUCCESS_OPERATION_STATE } from '../utils/constants';
+import { MIDDLEWARE_VERSION, OPERATION_TYPES, ROSETTA_VERSION, SUCCESS_OPERATION_STATE } from '../utils/constants';
 import { mapToNetworkList, mapToNetworkStatusResponse } from '../utils/data-mapper';
 import { ErrorFactory } from '../utils/errors';
 import { withNetworkValidation } from './controllers-helper';
@@ -71,7 +71,7 @@ const configure = (networkService: NetworkService, networkId: string, cardanoNod
           },
           allow: {
             operation_statuses: [SUCCESS_OPERATION_STATE],
-            operation_types: [operationType.INPUT, operationType.OUTPUT],
+            operation_types: OPERATION_TYPES,
             errors: Object.values(ErrorFactory)
               .map(fn => fn())
               // Return them sorted by code

--- a/cardano-rosetta-server/src/server/utils/constants.ts
+++ b/cardano-rosetta-server/src/server/utils/constants.ts
@@ -30,6 +30,8 @@ export enum operationType {
   STAKE_KEY_DEREGISTRATION = 'stakeKeyDeregistration'
 }
 
+export const OPERATION_TYPES = Object.values(operationType);
+
 export const stakingOperations = [
   operationType.STAKE_DELEGATION,
   operationType.STAKE_KEY_REGISTRATION,

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -3,7 +3,7 @@ import { Pool } from 'pg';
 import { FastifyInstance } from 'fastify';
 import StatusCodes from 'http-status-codes';
 import { setupDatabase, setupServer, testInvalidNetworkParameters } from '../utils/test-utils';
-import { CARDANO, MAINNET, operationType } from '../../../src/server/utils/constants';
+import { CARDANO, MAINNET, OPERATION_TYPES } from '../../../src/server/utils/constants';
 import { generateNetworkPayload } from './common';
 import packageJson from '../../../package.json';
 
@@ -16,7 +16,7 @@ const allow = {
       successful: true
     }
   ],
-  operation_types: [operationType.INPUT, operationType.OUTPUT],
+  operation_types: OPERATION_TYPES,
   errors: [
     {
       code: 4001,


### PR DESCRIPTION
# Description

We forgot to add the operation sin the proper `network` endpoint so `rosetta-cli` was complaining about it with the following error:

```bash
Error: unable to fetch block 4500003: Operation.Type is invalid: stakeKeyRegistration: operation type is invalid
```

# Proposed Solution

Just added the operations as an array taken from the `enum` and now everything seems to be working just fine

# Important Changes Introduced

n/a

# Testing

- `rosetta-cli` where block `4500003` is contained (as it has a staking operation)
