### PR TITLE
fix: missing parameter in cardano service linter fixes

### DIFF
--- a/cardano-rosetta-server/test/e2e/construction/construction-metadata-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-metadata-api.test.ts
@@ -4,7 +4,7 @@ import StatusCodes from 'http-status-codes';
 import { Pool } from 'pg';
 import { FastifyInstance } from 'fastify';
 import { linearFeeParameters, setupDatabase, setupServer, testInvalidNetworkParameters } from '../utils/test-utils';
-import { latestBlockSlot, SIGNED_TRANSACTION, TRANSACTION_SIZE_IN_BYTES } from '../fixture-data';
+import { latestBlockSlot, TRANSACTION_SIZE_IN_BYTES } from '../fixture-data';
 
 const CONSTRUCTION_METADATA_ENDPOINT = '/construction/metadata';
 

--- a/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
@@ -27,7 +27,7 @@ const CONSTRUCTION_PREPROCESS_ENDPOINT = '/construction/preprocess';
 type ProcessPayloadType = {
   blockchain?: string;
   network?: string;
-  operations?: any[];
+  operations?: Components.Schemas.Operation[];
   relativeTtl?: number;
 };
 

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -1948,16 +1948,11 @@ export const CONSTRUCTION_PAYLOADS_REQUEST_INVALID_INPUTS = {
 // Parse operations as the same as the ones sent before but status should be empty
 export const constructionParseOperations = (
   constructionPayloadRequest: Components.Schemas.ConstructionPayloadsRequest
-) =>
+): Components.Schemas.Operation[] =>
   constructionPayloadRequest.operations.map(operation => ({
     ...operation,
     status: ''
   }));
-
-export const CONSTRUCTION_PARSE_OPERATIONS = CONSTRUCTION_PAYLOADS_REQUEST.operations.map(operation => ({
-  ...operation,
-  status: ''
-}));
 
 export const CONSTRUCTION_PAYLOADS_REQUEST_INVALID_TRANSACTION_ID = {
   network_identifier: {

--- a/cardano-rosetta-server/test/unit/services/cardano-services.test.ts
+++ b/cardano-rosetta-server/test/unit/services/cardano-services.test.ts
@@ -1,10 +1,12 @@
 import configure, { EraAddressType, CardanoService } from '../../../src/server/services/cardano-services';
 
+const minKeyDeposit = 2000000;
+
 describe('Cardano Service', () => {
   let cardanoService: CardanoService;
 
   beforeAll(() => {
-    cardanoService = configure({ minFeeA: 0, minFeeB: 0 });
+    cardanoService = configure({ minFeeA: 0, minFeeB: 0 }, minKeyDeposit);
   });
 
   describe('Address type detection', () => {


### PR DESCRIPTION
# Description

- Adds the `minKeyDeposit` parameter that was missing in the cardano service unit tests (it wasn't used there since we don't include unit tests that need that value and, therefore the tests were passing but it was breaking the pipeline).
- Also fixed some linting warnings mainly in the e2e tests.
