### PR TITLE
ci: make the CI workflows run on any PR regardless of the target branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: Ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   pull_request:
     branches:
-      - master
+      - "**"
 
 jobs:
   tests:
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-and-snapshot-data:
-    runs-on: ubuntu-latest
+    runs-on: Ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/.github/workflows/post_integration.yml
+++ b/.github/workflows/post_integration.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   push-docker-build:
-    runs-on: ubuntu-latest
+    runs-on: Ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-push-release-builds:
-    runs-on: ubuntu-latest
+    runs-on: Ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test-builds:
-    runs-on: ubuntu-latest
+    runs-on: Ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -17,6 +17,7 @@ jobs:
         uses: ./.github/actions/smoke_test_cardano_rosetta
         with:
           tag: ${{ github.sha }}
+          test-exe: ./test/smoke_test.sh
       - name: Build from Git URL with local cache, configured for testnet
         run: docker build
           --build-arg NETWORK=testnet


### PR DESCRIPTION
# Description

- Changed the CI config so that it runs on every PR regardless of the branch, using ** pattern based on [this](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags).
- I also changed the environment name to make it lowercase, as specified in the [docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on).
