### PR TITLE
delegate-stake-example to consider 2 ada stake key registration fee

### DIFF
--- a/examples/commons.ts
+++ b/examples/commons.ts
@@ -2,9 +2,9 @@
 /* eslint-disable camelcase */
 /* eslint-disable new-cap */
 /* eslint-disable no-console */
-import delay from "delay";
-import * as NaCl from "tweetnacl";
-import axios from "axios";
+import delay from 'delay';
+import * as NaCl from 'tweetnacl';
+import axios from 'axios';
 
 const logger = console;
 
@@ -103,7 +103,7 @@ const buildOperation = (
   unspents: any,
   address: string,
   destination: string,
-  staking: boolean
+  isRegisteringStakeKey: boolean
 ) => {
   const inputs = unspents.coins.map((coin: any, index: number) => {
     const operation = {
@@ -129,11 +129,11 @@ const buildOperation = (
   });
   // TODO: No proper fees estimation is being done (it should be transaction size based)
   const totalBalance = BigInt(unspents.balances[0].value);
-  if (staking) {
-    var outputAmount;
-    var i = 0;
+  let outputAmount = (totalBalance * BigInt(95)) / BigInt(100);
+  if (isRegisteringStakeKey) {
+    let i = 0;
     do {
-      var dividend = 95 - i;
+      let dividend = 95 - i;
       outputAmount = (totalBalance * BigInt(dividend)) / BigInt(100);
       i += 5;
       if (outputAmount < 2500000) throw new Error(`outputAmount=${outputAmount} is too low. Try with more funds.`);

--- a/examples/commons.ts
+++ b/examples/commons.ts
@@ -102,7 +102,8 @@ const constructionMetadata = async (options: any) => {
 const buildOperation = (
   unspents: any,
   address: string,
-  destination: string
+  destination: string,
+  staking: boolean
 ) => {
   const inputs = unspents.coins.map((coin: any, index: number) => {
     const operation = {
@@ -128,7 +129,17 @@ const buildOperation = (
   });
   // TODO: No proper fees estimation is being done (it should be transaction size based)
   const totalBalance = BigInt(unspents.balances[0].value);
-  const outputAmount = (totalBalance * BigInt(95)) / BigInt(100);
+  if (staking) {
+    var outputAmount;
+    var i = 0;
+    do {
+      var dividend = 95 - i;
+      outputAmount = (totalBalance * BigInt(dividend)) / BigInt(100);
+      i += 5;
+      if (outputAmount < 2500000) throw new Error(`outputAmount=${outputAmount} is too low. Try with more funds.`);
+    }
+    while (totalBalance - outputAmount <= 2000000)
+  }
   const outputs = [
     {
       operation_identifier: {

--- a/examples/delegate-stake-example.ts
+++ b/examples/delegate-stake-example.ts
@@ -90,7 +90,8 @@ const doRun = async (): Promise<void> => {
   const builtOperations = buildOperation(
     unspents,
     paymentAddress,
-    SEND_FUNDS_ADDRESS
+    SEND_FUNDS_ADDRESS,
+    true
   );
   const currentIndex = builtOperations.operations.length - 1;
   const builtRegistrationOperation = buildRegistrationOperation(


### PR DESCRIPTION
# Description

`delegate-stake-example` currently fails with error `'The transaction you are trying to build has more outputs than inputs'` due to not considering the 2 ada staking key registration fee. This was observed when funding the payment address with 10/15/25 ada.

# Proposed Solution

This fix adjusts the output value so that 2 ada is reserved for this staking fee.

# Important Changes Introduced

None

# Testing

I have confirmed that now this example runs when payment address is funded with 10 ada. I also confirmed that error is thrown if there isn't at least 2.5 ada to cover staking registration and transaction fee.

