### PR TITLE
refactor: linter warning fixes

### DIFF
--- a/cardano-rosetta-server/src/server/db/blockchain-repository.ts
+++ b/cardano-rosetta-server/src/server/db/blockchain-repository.ts
@@ -171,7 +171,7 @@ const tryAddToken = <T extends TransactionInOut>(inOut: T, findResult: FindTrans
     if (!tokenBundle.tokens.has(policyAsHex)) {
       tokenBundle.tokens.set(policyAsHex, []);
     }
-    tokenBundle.tokens.get(policyAsHex)!.push({ name: nameAsHex, quantity });
+    tokenBundle.tokens.get(policyAsHex)?.push({ name: nameAsHex, quantity });
 
     return {
       ...inOut,

--- a/cardano-rosetta-server/src/server/services/cardano-services.ts
+++ b/cardano-rosetta-server/src/server/services/cardano-services.ts
@@ -20,7 +20,7 @@ import {
   PREFIX_LENGTH,
   PUBLIC_KEY_BYTES_LENGTH,
   SIGNATURE_LENGTH,
-  StakeType
+  StakeAddressPrefix
 } from '../utils/constants';
 import { ErrorFactory } from '../utils/errors';
 import { hexFormatter } from '../utils/formatters';
@@ -302,7 +302,9 @@ const configure = (linearFeeParameters: LinearFeeParameters, minKeyDeposit: numb
   },
   isStakeAddress(address) {
     const addressPrefix = this.getPrefixFromAddress(address);
-    return [StakeType.STAKE as string, StakeType.STAKE_TEST as string].some(type => addressPrefix.includes(type));
+    return [StakeAddressPrefix.MAIN as string, StakeAddressPrefix.TEST as string].some(type =>
+      addressPrefix.includes(type)
+    );
   },
   getHashOfSignedTransaction(logger, signedTransaction) {
     try {

--- a/cardano-rosetta-server/src/server/utils/cardano/addresses.ts
+++ b/cardano-rosetta-server/src/server/utils/cardano/addresses.ts
@@ -1,22 +1,21 @@
 import CardanoWasm, { Address, ByronAddress, StakeCredential } from 'cardano-serialization-lib';
 import { Logger } from 'fastify';
-import { NetworkIdentifier, EraAddressType } from '../constants';
+import {
+  NetworkIdentifier,
+  EraAddressType,
+  AddressPrefix,
+  StakeAddressPrefix,
+  NonStakeAddressPrefix
+} from '../constants';
 
 /**
- * Returns the bech-32 address prefix based on the netowrkId acording to
- * Prefix according to: https://github.com/cardano-foundation/CIPs/tree/master/CIP5#specification
+ * Returns the bech-32 address prefix based on the netowrkId
+ * Prefix according to: https://github.com/cardano-foundation/CIPs/blob/master/CIP-0005/CIP-0005.md
  * @param network number
+ * @param addressPrefix the corresponding prefix enum. Defaults to non stake address prefixes
  */
-export const getAddressPrefix = (network: number) =>
-  network === NetworkIdentifier.CARDANO_MAINNET_NETWORK ? 'addr' : 'addr_test';
-
-/**
- * Returns the bech-32 stake address prefix based on the netowrkId acording to
- * Prefix according to: https://github.com/cardano-foundation/CIPs/tree/master/CIP5#specification
- * @param network number
- */
-export const getStakeAddressPrefix = (network: number) =>
-  network === NetworkIdentifier.CARDANO_MAINNET_NETWORK ? 'stake' : 'stake_test';
+export const getAddressPrefix = (network: number, addressPrefix: AddressPrefix = NonStakeAddressPrefix): string =>
+  network === NetworkIdentifier.CARDANO_MAINNET_NETWORK ? addressPrefix.MAIN : addressPrefix.TEST;
 
 /**
  * Creates a new Reward address
@@ -31,7 +30,7 @@ export const generateRewardAddress = (
 ): string => {
   logger.info('[generateRewardAddress] Deriving cardano reward address from valid public staking key');
   const rewardAddress = CardanoWasm.RewardAddress.new(network, paymentCredential);
-  const bech32address = rewardAddress.to_address().to_bech32(getStakeAddressPrefix(network));
+  const bech32address = rewardAddress.to_address().to_bech32(getAddressPrefix(network, StakeAddressPrefix));
   logger.info(`[generateRewardAddress] reward address is ${bech32address}`);
   return bech32address;
 };

--- a/cardano-rosetta-server/src/server/utils/cardano/transactions-processor.ts
+++ b/cardano-rosetta-server/src/server/utils/cardano/transactions-processor.ts
@@ -134,6 +134,7 @@ const parseCertToOperation = (
   };
   const delegationCert = cert.as_stake_delegation();
   if (delegationCert) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     operation.metadata!.pool_key_hash = Buffer.from(delegationCert.pool_keyhash().to_bytes()).toString('hex');
   }
   return operation;
@@ -157,15 +158,17 @@ const parseCertsToOperations = (
     }
     const credential = getStakingCredentialFromHex(logger, stakingOperation.metadata?.staking_credential);
     const address = generateRewardAddress(logger, network, credential);
-    const cert = transactionBody.certs()!.get(i);
-    const parsedOperation = parseCertToOperation(
-      cert,
-      stakingOperation.operation_identifier.index,
-      hex,
-      stakingOperation.type,
-      address
-    );
-    parsedOperations.push(parsedOperation);
+    const cert = transactionBody.certs()?.get(i);
+    if (cert) {
+      const parsedOperation = parseCertToOperation(
+        cert,
+        stakingOperation.operation_identifier.index,
+        hex,
+        stakingOperation.type,
+        address
+      );
+      parsedOperations.push(parsedOperation);
+    }
   }
 
   return parsedOperations;
@@ -203,10 +206,13 @@ const parseWithdrawalsToOperations = (
   logger.info(`[parseWithdrawalsToOperations] About to parse ${withdrawalsCount} withdrawals`);
   for (let i = 0; i < withdrawalsCount; i++) {
     const withdrawalOperation = withdrawalOps[i];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const credential = getStakingCredentialFromHex(logger, withdrawalOperation.metadata!.staking_credential);
     const address = generateRewardAddress(logger, network, credential);
     const parsedOperation = parseWithdrawalToOperation(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       withdrawalOperation.amount!.value,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       withdrawalOperation.metadata!.staking_credential!.hex_bytes,
       withdrawalOperation.operation_identifier.index,
       address

--- a/cardano-rosetta-server/src/server/utils/constants.ts
+++ b/cardano-rosetta-server/src/server/utils/constants.ts
@@ -19,9 +19,18 @@ export const PUBLIC_KEY_BYTES_LENGTH = 64;
 export const POLICY_ID_LENGTH = 56;
 export const ASSET_NAME_LENGTH = 64;
 
-export enum StakeType {
-  STAKE = 'stake',
-  STAKE_TEST = 'stake_test'
+export enum NonStakeAddressPrefix {
+  MAIN = 'addr',
+  TEST = 'addr_test'
+}
+
+export enum StakeAddressPrefix {
+  MAIN = 'stake',
+  TEST = 'stake_test'
+}
+export interface AddressPrefix {
+  MAIN: string;
+  TEST: string;
 }
 
 export enum OperationType {

--- a/cardano-rosetta-server/src/server/utils/data-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/data-mapper.ts
@@ -24,7 +24,7 @@ export const mapAmount = (
   value: string,
   symbol = ADA,
   decimals = ADA_DECIMALS,
-  metadata?: any
+  metadata?: { policyId?: string }
 ): Components.Schemas.Amount => ({
   value,
   currency: {

--- a/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
@@ -196,6 +196,7 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
     });
     expect(response.statusCode).toEqual(StatusCodes.OK);
     // Address generated locally with following command (using private keys attached to issue #198):
+    // eslint-disable-next-line max-len
     // cat addr.prv | ./cardano-address key public | ./cardano-address address payment  --network-tag 1 | ./cardano-address address delegation $(cat stake.prv | ./cardano-address key public)
     expect(response.json().address).toEqual(
       'addr1q9dhy809valxaer3nlvg2h5nudd62pxp6lu0cs36zczhfr98y6pah6lvppk8xft57nef6yexqh6rr204yemcmm3emhzsgg4fg0'
@@ -230,6 +231,7 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
       })
     });
     expect(response.statusCode).toEqual(StatusCodes.OK);
+    // eslint-disable-next-line max-len
     // https://cardanoscan.io/address/015b721de5677e6ee4719fd8855e93e35ba504c1d7f8fc423a1605748ca72683dbebec086c732574f4f29d132605f431a9f526778dee39ddc5
     expect(response.json().address).toEqual('stake1uxnjdq7ma0kqsmrny460fu5azvnqtap3486jvaudacuam3g3yc4nu');
   });

--- a/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
@@ -6,7 +6,8 @@ import {
   setupOfflineDatabase,
   setupServer,
   testInvalidNetworkParameters,
-  modifyMAOperation
+  modifyMAOperation,
+  modifyCoinChange
 } from '../utils/test-utils';
 import {
   CONSTRUCTION_PAYLOADS_MULTIPLE_INPUTS,
@@ -152,19 +153,14 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
       retriable: false,
       details: {
         message:
+          // eslint-disable-next-line max-len
           'Invalid input: ThisIsAnInvalidAddressaddr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx - mixed-case strings not allowed'
       }
     });
   });
 
   test('Should return an error when input operation has no coin change property', async () => {
-    const { operations, ...restPayload } = CONSTRUCTION_PAYLOADS_REQUEST;
-    const payload = {
-      operations: operations.map(({ coin_change, ...restOperation }) => ({
-        ...restOperation
-      })),
-      ...restPayload
-    };
+    const payload = modifyCoinChange(CONSTRUCTION_PAYLOADS_REQUEST);
     const response = await server.inject({
       method: 'post',
       url: CONSTRUCTION_PAYLOADS_ENDPOINT,
@@ -178,19 +174,12 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
   });
 
   test('Should return an error when input operation has invalid coin identifier', async () => {
-    const { operations, ...restPayload } = CONSTRUCTION_PAYLOADS_REQUEST;
-    const payload = {
-      operations: operations.map(({ coin_change, ...restOperation }) => ({
-        coin_change: {
-          coin_identifier: {
-            identifier: 'invalid_coin_identifier'
-          },
-          coin_action: 'coin_spent'
-        },
-        ...restOperation
-      })),
-      ...restPayload
-    };
+    const payload = modifyCoinChange(CONSTRUCTION_PAYLOADS_REQUEST, {
+      coin_identifier: {
+        identifier: 'invalid_coin_identifier'
+      },
+      coin_action: 'coin_spent'
+    });
     const response = await server.inject({
       method: 'post',
       url: CONSTRUCTION_PAYLOADS_ENDPOINT,
@@ -513,7 +502,7 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
       network_identifier,
       operations: operations.map(({ metadata: opMetadata, ...rest }) => ({
         metadata: opMetadata && {
-          staking_credential: { hex_bytes: opMetadata.staking_credential!.hex_bytes, curve_type: 'secp256k1' }
+          staking_credential: { hex_bytes: opMetadata.staking_credential?.hex_bytes, curve_type: 'secp256k1' }
         },
         ...rest
       })),

--- a/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
@@ -133,6 +133,7 @@ describe(CONSTRUCTION_PREPROCESS_ENDPOINT, () => {
       retriable: false,
       details: {
         message:
+          // eslint-disable-next-line max-len
           'Invalid input: ThisIsAnInvalidAddressaddr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx - mixed-case strings not allowed'
       }
     });
@@ -546,6 +547,7 @@ describe(CONSTRUCTION_PREPROCESS_ENDPOINT, () => {
         code: 4009,
         details: {
           message:
+            // eslint-disable-next-line max-len
             'Token name 6e7574636f696e has already been added for policy b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a7 and will be overriden'
         },
         message: invalidOperationErrorMessage,

--- a/cardano-rosetta-server/test/e2e/environment-parser.test.ts
+++ b/cardano-rosetta-server/test/e2e/environment-parser.test.ts
@@ -35,6 +35,7 @@ describe('Environment parser test', () => {
       throw new Error(code?.toString());
     });
     expect(environmentParser).toThrowError(Error);
+    expect(mockExit).toHaveBeenCalledWith(1);
     process.env.TOPOLOGY_FILE_PATH = previousPath;
   });
   test('Should throw an error if a field is expected to be a valid host but its not', () => {

--- a/cardano-rosetta-server/test/unit/utils/cardano/cli/cardanonode-cli.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/cardano/cli/cardanonode-cli.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len  */
 import { Logger } from 'fastify';
 import { configure, SUPPORTED_ERAS } from '../../../../../src/server/utils/cardano/cli/cardanonode-cli';
 


### PR DESCRIPTION
# Description

This PR removes linter warnings.

# Proposed Solution

- Disable unneeded rules for sepecific lines (most of them because some validations where already made before those lines and the rules were redundant).
- Add missing return types to functions.
- Refactor `getAddressPrefix` function to make it more general for both staking and non staking addresses.

