### PR TITLE
Add cli check:data for Multi-Asset on Launchpad

### DIFF
--- a/test/check/README.md
+++ b/test/check/README.md
@@ -9,6 +9,10 @@ Run a mainnet instance with the server exposed at `http://localhost:8080`
 ./bin/rosetta-cli check:data --configuration-file ./configuration/data/shelley_sample.json
 ./bin/rosetta-cli check:data --configuration-file ./configuration/data/shelley_transition.json
 ```
+Run a launchpad instance with the server exposed at `http://localhost:8082`
+``` console
+./bin/rosetta-cli check:data --configuration-file ./configuration/data/mary_sample.json
+```
 
 ## `construction`
 

--- a/test/check/configuration/data/mary_sample.json
+++ b/test/check/configuration/data/mary_sample.json
@@ -1,0 +1,16 @@
+{
+  "online_url": "http://localhost:8082",
+  "data": {
+    "start_index":  382301,
+    "end_conditions": {
+      "index":  382400
+    }
+  },
+  "network": {
+    "blockchain": "cardano",
+    "network": "3"
+  },
+  "http_timeout": 100000,
+  "tip_delay": 10000,
+  "max_sync_concurrency": 32
+}


### PR DESCRIPTION
# Description

Adds configuration file for rosetta-cli check:data on `launchpad` for blocks containing Multi-Asset (MA) transactions.

# Proposed Solution

N/A

# Important Changes Introduced

None

# Testing

Run new check configuration, see updated readme.

