### PR TITLE
feat(payloads): invalid pool key hash error handling

### DIFF
--- a/cardano-rosetta-server/.eslintrc
+++ b/cardano-rosetta-server/.eslintrc
@@ -6,5 +6,8 @@
     "import/resolver": {
       "typescript": {}
     }
+  },
+  "rules": {
+    "quotes": ["error", "single", { "avoidEscape": true }]
   }
 }

--- a/cardano-rosetta-server/src/server/utils/errors.ts
+++ b/cardano-rosetta-server/src/server/utils/errors.ts
@@ -67,8 +67,9 @@ export const Errors = {
     code: 4019
   },
   POOL_KEY_MISSING: { message: 'Pool key hash is required for stake delegation', code: 4020 },
-  TOKEN_BUNDLE_ASSETS_MISSING: { message: 'Assets are required for output operation token bundle', code: 4021 },
-  TOKEN_ASSET_VALUE_MISSING: { message: 'Asset value is required for token asset', code: 4022 },
+  INVALID_POOL_KEY_HASH: { message: 'Provided pool key hash has invalid format', code: 4021 },
+  TOKEN_BUNDLE_ASSETS_MISSING: { message: 'Assets are required for output operation token bundle', code: 4022 },
+  TOKEN_ASSET_VALUE_MISSING: { message: 'Asset value is required for token asset', code: 4023 },
   UNSPECIFIED_ERROR: { message: 'An error occurred', code: 5000 },
   NOT_IMPLEMENTED: { message: 'Not implemented', code: 5001 },
   ADDRESS_GENERATION_ERROR: { message: 'Address generation error', code: 5002 },
@@ -102,6 +103,7 @@ const invalidPublicKeyFormat: CreateErrorFunction = () => buildApiError(Errors.I
 const invalidStakingKeyFormat: CreateErrorFunction = () => buildApiError(Errors.INVALID_STAKING_KEY_FORMAT, false);
 const missingStakingKeyError: CreateErrorFunction = type => buildApiError(Errors.STAKING_KEY_MISSING, false, type);
 const missingPoolKeyError: CreateErrorFunction = type => buildApiError(Errors.POOL_KEY_MISSING, false, type);
+const invalidPoolKeyError: CreateErrorFunction = details => buildApiError(Errors.INVALID_POOL_KEY_HASH, false, details);
 const parseSignedTransactionError: CreateErrorFunction = () =>
   buildApiError(Errors.PARSE_SIGNED_TRANSACTION_ERROR, false);
 const cantBuildWitnessesSet: CreateErrorFunction = () => buildApiError(Errors.CANT_BUILD_WITNESSES_SET, false);
@@ -144,6 +146,7 @@ export const ErrorFactory = {
   invalidStakingKeyFormat,
   missingStakingKeyError,
   missingPoolKeyError,
+  invalidPoolKeyError,
   parseSignedTransactionError,
   cantBuildSignedTransaction,
   cantBuildWitnessesSet,

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -96,11 +96,16 @@ const allow = {
     },
     {
       code: 4021,
-      message: 'Assets are required for output operation token bundle',
+      message: 'Provided pool key hash has invalid format',
       retriable: false
     },
     {
       code: 4022,
+      message: 'Assets are required for output operation token bundle',
+      retriable: false
+    },
+    {
+      code: 4023,
       message: 'Asset value is required for token asset',
       retriable: false
     },

--- a/cardano-rosetta-server/test/e2e/utils/test-utils.ts
+++ b/cardano-rosetta-server/test/e2e/utils/test-utils.ts
@@ -127,3 +127,14 @@ export const modifyCoinChange = (
     findBy((operation: Components.Schemas.Operation) => operation && operation.type === OperationType.INPUT),
     'coin_change'
   )(() => coinChange)(payload);
+
+export const modifyPoolKeyHash = (
+  payload: Components.Schemas.ConstructionPayloadsRequest,
+  poolKeyHash?: string
+): Components.Schemas.ConstructionPayloadsRequest =>
+  mod(
+    'operations',
+    findBy((operation: Components.Schemas.Operation) => operation && operation.type === OperationType.STAKE_DELEGATION),
+    'metadata',
+    'pool_key_hash'
+  )(() => poolKeyHash)(payload);


### PR DESCRIPTION
# Description

The `/construction/payloads` endpoint now returns a more specific error when an invalid pool key hash is provided for a stake delegation operation.

# Proposed Solution

New function implemented with the already existing validation for no pool key hash provided and with the new one if the format is not valid.

# Important Changes Introduced

New error type was introduced and the numbers of others have been adapted.

# Testing

New e2e test has been added to assert this error and it is run as usual with the rest.

# References

This improves the error message that appears in the scenario mentioned in issue #286