### PR TITLE
fix: validate asset values are positive number for output operations

### DIFF
--- a/cardano-rosetta-server/src/server/utils/cardano/operations-processor.ts
+++ b/cardano-rosetta-server/src/server/utils/cardano/operations-processor.ts
@@ -17,7 +17,7 @@ import { isPolicyIdValid, isTokenNameValid } from '../validations';
 import { generateRewardAddress } from './addresses';
 import { getStakingCredentialFromHex } from './staking-credentials';
 
-const isNumeric = (value: string): boolean => /^\d+$/.test(value);
+const isPositiveNumber = (value: string): boolean => /^\+?\d+/.test(value);
 
 /**
  * This function validates and parses token bundles that might be attached to unspents
@@ -58,7 +58,7 @@ const validateAndParseTokenBundle = (
           `Token with name ${tokenName} for policy ${multiAsset.policyId} has no value or is empty`
         );
       }
-      if (!isNumeric(asset.value)) {
+      if (!isPositiveNumber(asset.value)) {
         logger.error(`[validateAndParseTokenBundle] Asset ${tokenName} has negative or invalid value '${asset.value}'`);
         throw ErrorFactory.transactionOutputsParametersMissingError(
           `Asset ${tokenName} has negative or invalid value '${asset.value}'`
@@ -91,7 +91,7 @@ const validateAndParseTransactionOutput = (
     logger.error('[validateAndParseTransactionOutput] Output has missing amount value field');
     throw ErrorFactory.transactionOutputsParametersMissingError('Output has missing amount value field');
   }
-  if (!isNumeric(outputValue)) {
+  if (!isPositiveNumber(outputValue)) {
     logger.error(`[validateAndParseTransactionOutput] Output has negative or invalid value '${outputValue}'`);
     throw ErrorFactory.transactionOutputsParametersMissingError('Output has negative amount value');
   }
@@ -123,7 +123,7 @@ const validateAndParseTransactionInput = (
     logger.error('[validateAndParseTransactionInput] Input has missing amount value field');
     throw ErrorFactory.transactionInputsParametersMissingError('Input has missing amount value field');
   }
-  if (/^\+?\d+/.test(value)) {
+  if (isPositiveNumber(value)) {
     logger.error('[validateAndParseTransactionInput] Input has positive value');
     throw ErrorFactory.transactionInputsParametersMissingError('Input has positive amount value');
   }

--- a/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
@@ -418,7 +418,7 @@ describe(CONSTRUCTION_PREPROCESS_ENDPOINT, () => {
       });
     });
 
-    test('Should fail if MultiAsset value is negative', async () => {
+    test('Should fail if MultiAsset value for output operation is negative', async () => {
       const value = '-10000';
       const operations = mod(
         1,


### PR DESCRIPTION
# Description

Adds token asset value validation. It must be a positive number for output operations.
Also adds some logging calls.

Resolves #294 

