### PR TITLE
Add example for tx with ma operations and update docs for multi assets implementation

### DIFF
--- a/docs/multi-assets-support.md
+++ b/docs/multi-assets-support.md
@@ -1,0 +1,78 @@
+# Multi Assets support
+
+# Operations with multi assets
+
+Multi Assets are allowed for inputs and outputs operations.
+
+For operations sent in the request of the `/construction/preprocess` and `/construction/payloads` endpoints will have the list of Token Bundles associated to each operation as metadata.
+
+More information about Multi Assets structure can be found [here](https://developers.cardano.org/en/development-environments/native-tokens/multi-asset-tokens-explainer/).
+
+Both token symbol and policy will be passed as hex string as follows:
+
+### Input operation
+
+```json
+{
+  "operation_identifier": { "index": 0, "network_index": 0 },
+  "type": "input",
+  "status": "success",
+  "account": {
+    "address": "addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx"
+  },
+  "amount": {
+    "value": "-90000",
+    "currency": { "symbol": "ADA", "decimals": 6 }
+  },
+  "coin_change": {
+    "coin_identifier": {
+      "identifier": "2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1"
+    },
+    "coin_action": "coin_spent"
+  },
+  "metadata": {
+    "tokenBundle": [
+      {
+        "policyId": "b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a7",
+        "tokens": [
+          {
+            "value": "10000",
+            "currency": { "symbol": "6e7574636f696e", "decimals": 0 }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Output operation
+
+```json
+{
+  "operation_identifier": { "index": 1 },
+  "related_operations": [{ "index": 0 }],
+  "type": "output",
+  "status": "success",
+  "account": {
+    "address": "addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx"
+  },
+  "amount": {
+    "value": "10000",
+    "currency": { "symbol": "ADA", "decimals": 6 }
+  },
+  "metadata": {
+    "tokenBundle": [
+      {
+        "policyId": "b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a7",
+        "tokens": [
+          {
+            "value": "10000",
+            "currency": { "symbol": "6e7574636f696e", "decimals": 0 }
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/docs/rosetta-custom-definitions.md
+++ b/docs/rosetta-custom-definitions.md
@@ -66,6 +66,102 @@ In this case the metadata is optional. If it's provided, then the `address_type`
 }
 ```
 
+## `/account/balance`
+
+For accounts that have a multi asset balance there will be returned with the corresponding policy passed as metadata at `currency` as follows:
+
+### Response
+
+```typescript
+{
+  "block_identifier": {
+    "index": 382733,
+    "hash": "50bb3491000528b19a074291bd958b77dd0b8b1cf3003bf14d1ac24a62073f1e"
+  },
+  "balances": [
+    { "value": "4800000", "currency": { "symbol": "ADA", "decimals": 6 } },
+   {
+      "value": "20",
+      "currency": {
+        "symbol": "",                                                               // token symbol as hex string
+        "decimals": 0,
+        "metadata": {
+          "policyId": "181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e"    // token policy as hex string
+        }
+      }
+    },
+    {
+      "value": "10",
+      "currency": {
+        "symbol": "7376c3a57274",
+        "decimals": 0,
+        "metadata": {
+          "policyId": "fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d"
+        }
+      }
+    }
+  ],
+  "coins": [...]
+}
+```
+
+Also, `coins` will be returned with the token bundle list corresponding to each coin as metadata as follows:
+
+```typescript
+{
+  "block_identifier": {
+    "index": 382733,
+    "hash": "50bb3491000528b19a074291bd958b77dd0b8b1cf3003bf14d1ac24a62073f1e"
+  },
+  "balances": [...],
+  "coins": [
+    {
+      "coin_identifier": {
+        "identifier": "02562c123f6d560e1250f5a46f7e95911b21fd8a9fa70157335c3a3d1d16bdda:0"
+      },
+      "amount": {
+        "currency": { "decimals": 6, "symbol": "ADA" },
+        "value": "4800000"
+      },
+      "metadata": {
+        "02562c123f6d560e1250f5a46f7e95911b21fd8a9fa70157335c3a3d1d16bdda:0": [       // coin identifier
+          {
+            "policyId": "181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e",   
+            "tokens": [
+              {
+                "value": "20",
+                "currency": {
+                  "decimals": 0,
+                  "symbol": "",                                                       
+                  "metadata": {
+                    "policyId": "181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "policyId": "fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d",
+            "tokens": [
+              {
+                "value": "10",
+                "currency": {
+                  "decimals": 0,
+                  "symbol": "7376c3a57274",
+                  "metadata": {
+                    "policyId": "fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
 ## `/block`
 
 The following metadata is also returned when querying for block information:
@@ -115,9 +211,67 @@ The following metadata is also returned when querying for block information:
 }
 ```
 
+## `/block/transactions`
+
+If the block requested contains transactions with multi assets operations the token bundles associated to each operation will be returned as metadata as follows: 
+
+### Response
+
+```typescript
+{
+  "transaction_identifier": {
+    "hash": "2356072a5379064aa62f83bf61d7d4467dbc47ec281461b558aa51b08c38c884"
+  },
+  "operations": [
+    {
+      "operation_identifier": {
+        "index": 0
+      },
+      "type": "input",
+      "status": "success",
+      "account": {
+        "address": "addr_test1vpcv26kdu8hr9x939zktp275xhwz4478c8hcdt7l8wrl0ecjftnfa"
+      },
+      "amount": {
+        "value": "-999999000000",
+        "currency": {
+          "symbol": "ADA",
+          "decimals": 6
+        }
+      },
+      "coin_change": {
+        "coin_identifier": {
+          "identifier": "127cf01f95448cdcde439b8ace9b8a8ec100e690abe2b52069b3dbd924e032b3:0"
+        },
+        "coin_action": "coin_spent"
+      },
+      "metadata": {
+        "tokenBundle": [
+          {
+            "policyId": "3e6fc736d30770b830db70994f25111c18987f1407585c0f55ca470f",
+            "tokens": [
+              {
+                "value": "-5",
+                "currency": {
+                  "symbol": "6a78546f6b656e31",
+                  "decimals": 0
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    ...
+  ]
+}
+```
+
 ## `/construction/preprocess`
 
 Not only input and output operations are allowed but also special staking operations as described in [here](./staking-support.md).
+
+It is possible to operate with multi assets tokens too, as explained [here](./multi-assets-support.md).
 
 Cardano transactions require a `ttl` to be defined. As it's explained [in the cardano docs](https://docs.cardano.org/projects/cardano-node/en/latest/reference/building-and-signing-tx.html):
 
@@ -205,6 +359,8 @@ Metadata endpoint needs to receive the `relative_ttl` returned in process so it 
 ## `/construction/payloads`
 
 Not only input and output operations are allowed but also special staking operations as described in [here](./staking-support.md).
+
+It is possible to operate with multi assets tokens too, as explained [here](./multi-assets-support.md).
 
 Furthermore, transaction `ttl` needs to be sent as string in the metadata.
 

--- a/docs/rosetta-custom-definitions.md
+++ b/docs/rosetta-custom-definitions.md
@@ -213,7 +213,9 @@ The following metadata is also returned when querying for block information:
 
 ## `/block/transactions`
 
-If the block requested contains transactions with multi assets operations the token bundles associated to each operation will be returned as metadata as follows: 
+When the block requested contains transactions with multi assets operations the token bundles associated to each operation will be returned as metadata as follows: 
+
+_Also, assets will be returned sorted by name._
 
 ### Response
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -77,3 +77,22 @@ In order to execute the example, run:
 ```javascript
 $ yarn withdrawal-example
 ```
+
+## Sending transactions with single multi assets
+
+Sends a transaction that spends a single MultiAsset token. So:
+
+1. A predefined address `PAYMENT_ADDRESS` expects a specific token
+2. Sends `total token amount` to another predefined address `SEND_FUNDS_ADDRESS`
+3. All the ADA is also sent to that address 
+
+Important notes:
+- `EXPECTED_TOKEN` will be used to define the token expected. It requires policy and symbol both defined as hex string.
+- Running this example requieres a sender that owns tokens (for example by minting) and can send them to the rosetta-cli generated address. It's strongly recommended to use [this helper scripts](https://github.com/james-iohk/scripts)
+- Funds will be sent to `SEND_FUNDS_ADDRESS` by default as it's the address where testnet funds should be returned.
+
+In order to execute the example, run:
+
+```javascript
+$ yarn ma-transfer-example
+```

--- a/examples/commons.ts
+++ b/examples/commons.ts
@@ -129,10 +129,14 @@ const buildOperation = (
     };
     if (coin.metadata) {
       const coinsWithMa = Object.keys(coin.metadata);
-      tokenBundle.push(coinsWithMa.reduce((tokenBundleList, coinWithMa) => {
-        const tokenBundleItems = coin.metadata[coinWithMa];
-        return tokenBundleList.concat(tokenBundleItems);
-      }, []));
+      const coinTokenBundleItems = coinsWithMa.reduce(
+        (tokenBundleList, coinWithMa) => {
+          const tokenBundleItems = coin.metadata[coinWithMa];
+          return tokenBundleList.concat(tokenBundleItems);
+        },
+        []
+      );
+      tokenBundle.push(...coinTokenBundleItems);
       operation.metadata = { tokenBundle };
     }
     operation.amount.value = `-${operation.amount.value}`;
@@ -181,10 +185,9 @@ const buildOperation = (
 
   return {
     network_identifier,
-    operations: inputs.concat(outputs)
+    operations: inputs.concat(outputs),
   };
 };
-
 
 const constructionPayloads = async (payload: any) => {
   const response = await httpClient.post("/construction/payloads", {

--- a/examples/commons.ts
+++ b/examples/commons.ts
@@ -14,7 +14,7 @@ const httpClient = axios.create({
 
 const network_identifier = {
   blockchain: "cardano",
-  network: 3,
+  network: "testnet",
 };
 
 const generateKeys = (secretKey?: string) =>
@@ -67,9 +67,10 @@ const waitForBalanceToBe = async (
       },
     });
     if (cond(response.data)) {
-      const [balance] = response.data.balances;
-      logger.info(
-        `[waitForBalanceToBe] Funds found! ${balance.value} ${balance.currency.symbol}`
+      const { balances } = response.data;
+      logger.info("[waitForBalanceToBe] Funds found!");
+      balances.forEach((balance) =>
+        logger.info(`[waitForBalanceToBe] ${balance.value} ${balance.currency.symbol}`)
       );
       fetchAccountBalance = response.data;
     } else {

--- a/examples/ma-transfer-example.ts
+++ b/examples/ma-transfer-example.ts
@@ -3,7 +3,6 @@
 /* eslint-disable new-cap */
 /* eslint-disable no-console */
 import {
-  constructionDerive,
   constructionPreprocess,
   constructionMetadata,
   constructionPayloads,
@@ -12,30 +11,35 @@ import {
   signPayloads,
   waitForBalanceToBe,
   buildOperation,
-  generateKeys,
 } from "./commons";
 const logger = console;
 
-const PRIVATE_KEY =
-  "41d9523b87b9bd89a4d07c9b957ae68a7472d8145d7956a692df1a8ad91957a2c117d9dd874447f47306f50a650f1e08bf4bec2cfcb2af91660f23f2db912977";
+// address with ma balance
+const PAYMENT_ADDRESS =
+  "addr_test1vpcv26kdu8hr9x939zktp275xhwz4478c8hcdt7l8wrl0ecjftnfa";
+
+const PAYMENT_KEYS = {
+  secretKey: Buffer.from(
+    "67b638cef68135c4005cb71782b070c4805c9e1077c7ab6145b152206073272974dabdc594506574a9b58f719787d36ea1af291d141d3e5e5ccfe076909ae106",
+    "hex"
+  ),
+  publicKey: Buffer.from(
+    "74dabdc594506574a9b58f719787d36ea1af291d141d3e5e5ccfe076909ae106",
+    "hex"
+  ),
+};
+
 const SEND_FUNDS_ADDRESS =
-  "addr1qqr585tvlc7ylnqvz8pyqwauzrdu0mxag3m7q56grgmgu7sxu2hyfhlkwuxupa9d5085eunq2qywy7hvmvej456flknsug829n";
+  "addr_test1vz4nrdp83nksz0w3szxpav2peasm0xsdfc44lt2ml20420qclwuqu";
 
 const doRun = async (): Promise<void> => {
   const keyAddressMapper = {};
-  const keys = generateKeys(PRIVATE_KEY);
-  logger.info(
-    `[doRun] secretKey ${Buffer.from(keys.secretKey).toString("hex")}`
-  );
-  const address = await constructionDerive(
-    Buffer.from(keys.publicKey).toString("hex")
-  );
-  keyAddressMapper[address] = keys;
+  keyAddressMapper[PAYMENT_ADDRESS] = PAYMENT_KEYS;
   const unspents = await waitForBalanceToBe(
-    address,
+    PAYMENT_ADDRESS,
     (response) => response.coins.length !== 0
   );
-  const builtOperations = buildOperation(unspents, address, SEND_FUNDS_ADDRESS);
+  const builtOperations = buildOperation(unspents, PAYMENT_ADDRESS, SEND_FUNDS_ADDRESS);
   const preprocess = await constructionPreprocess(
     builtOperations.operations,
     1000
@@ -55,7 +59,7 @@ const doRun = async (): Promise<void> => {
   logger.info(
     `[doRun] transaction with hash ${hashResponse.transaction_identifier.hash} sent`
   );
-  await waitForBalanceToBe(address, (response) => response.coins.length === 0);
+  await waitForBalanceToBe(PAYMENT_ADDRESS, (response) => response.coins.length === 0);
 };
 
 doRun()

--- a/examples/ma-transfer-example.ts
+++ b/examples/ma-transfer-example.ts
@@ -49,6 +49,7 @@ const doRun = async (): Promise<void> => {
         balance.currency?.metadata?.policyId === EXPECTED_TOKEN.policy
     );
 
+  logger.info(`[doRun] address ${PAYMENT_ADDRESS} expects to receive funds.`);
   const unspents = await waitForBalanceToBe(PAYMENT_ADDRESS, responseCondition);
   const builtOperations = buildOperation(
     unspents,

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "send-transactions-example": "ts-node ./send-transaction-example.ts",
     "delegate-stake-example": "ts-node ./delegate-stake-example.ts",
-    "withdrawal-example": "ts-node ./withdrawal-example.ts"
+    "withdrawal-example": "ts-node ./withdrawal-example.ts",
+    "ma-transfer-example": "ts-node ./ma-transfer-example.ts"
   },
   "dependencies": {
     "@emurgo/cardano-serialization-lib-nodejs": "2.0.0",


### PR DESCRIPTION
# Description

Adds a TypeScript script for sending a transaction with multi assets at `examples/` and also updates the documentation for multi assets implementation.

# References

Closes #275.

