### PR TITLE
feat: validate token policy and symbol to be a hex string

### DIFF
--- a/cardano-rosetta-server/src/server/utils/validations.ts
+++ b/cardano-rosetta-server/src/server/utils/validations.ts
@@ -1,5 +1,9 @@
 import { PUBLIC_KEY_BYTES_LENGTH, AddressType, CurveType, ASSET_NAME_LENGTH, POLICY_ID_LENGTH } from './constants';
 
+const tokenNameValidation = new RegExp(`^[0-9a-fA-F]{0,${ASSET_NAME_LENGTH}}$`);
+
+const policyIdValidation = new RegExp(`^[0-9a-fA-F]{${POLICY_ID_LENGTH}}$`);
+
 export const VALID_CURVE_TYPE = CurveType.edwards25519;
 
 export const isKeyValid = (publicKeyBytes: string, curveType: string): boolean =>
@@ -8,8 +12,6 @@ export const isKeyValid = (publicKeyBytes: string, curveType: string): boolean =
 export const isAddressTypeValid = (type: string): boolean =>
   [...Object.values(AddressType), '', undefined].includes(type);
 
-export const isTokenNameValid = (name: string): boolean =>
-  new RegExp(`^[0-9a-fA-F]{0,${ASSET_NAME_LENGTH}}$`).test(name);
+export const isTokenNameValid = (name: string): boolean => tokenNameValidation.test(name);
 
-export const isPolicyIdValid = (policyId: string): boolean =>
-  new RegExp(`^[0-9a-fA-F]{${POLICY_ID_LENGTH}}$`).test(policyId);
+export const isPolicyIdValid = (policyId: string): boolean => policyIdValidation.test(policyId);

--- a/cardano-rosetta-server/src/server/utils/validations.ts
+++ b/cardano-rosetta-server/src/server/utils/validations.ts
@@ -8,6 +8,8 @@ export const isKeyValid = (publicKeyBytes: string, curveType: string): boolean =
 export const isAddressTypeValid = (type: string): boolean =>
   [...Object.values(AddressType), '', undefined].includes(type);
 
-export const isTokenNameValid = (name: string): boolean => name.length <= ASSET_NAME_LENGTH;
+export const isTokenNameValid = (name: string): boolean =>
+  new RegExp(`^[0-9a-fA-F]{0,${ASSET_NAME_LENGTH}}$`).test(name);
 
-export const isPolicyIdValid = (policyId: string): boolean => policyId.length === POLICY_ID_LENGTH;
+export const isPolicyIdValid = (policyId: string): boolean =>
+  new RegExp(`^[0-9a-fA-F]{${POLICY_ID_LENGTH}}$`).test(policyId);

--- a/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
@@ -652,6 +652,29 @@ describe('Invalid request with MultiAssets', () => {
     });
   });
 
+  test('Should fail if MultiAsset policy id is not a hex string', async () => {
+    const invalidPolicy = 'thisIsANonHexString';
+    const { operations, ...restPayload } = CONSTRUCTION_PAYLOADS_REQUEST_WITH_MA;
+    const payload = {
+      operations: modifyMAOperation(invalidPolicy)(operations),
+      ...restPayload
+    };
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_PAYLOADS_ENDPOINT,
+      payload
+    });
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({
+      code: 4009,
+      details: {
+        message: `PolicyId ${invalidPolicy} is not valid`
+      },
+      message: invalidOperationErrorMessage,
+      retriable: false
+    });
+  });
+
   test('Should fail if MultiAsset policy id is longer than expected', async () => {
     // eslint-disable-next-line no-magic-numbers
     const invalidPolicy = new Array(POLICY_ID_LENGTH + 2).join('0');
@@ -670,6 +693,30 @@ describe('Invalid request with MultiAssets', () => {
       code: 4009,
       details: {
         message: `PolicyId ${invalidPolicy} is not valid`
+      },
+      message: invalidOperationErrorMessage,
+      retriable: false
+    });
+  });
+
+  test('Should fail if MultiAsset symbol is not a hex string', async () => {
+    const invalidSymbol = 'thisIsANonHexString';
+    const { operations, ...restPayload } = CONSTRUCTION_PAYLOADS_REQUEST_WITH_MA;
+    const payload = {
+      operations: modifyMAOperation(undefined, invalidSymbol)(operations),
+      ...restPayload
+    };
+
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_PAYLOADS_ENDPOINT,
+      payload
+    });
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({
+      code: 4009,
+      details: {
+        message: `Token name ${invalidSymbol} is not valid`
       },
       message: invalidOperationErrorMessage,
       retriable: false

--- a/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
@@ -342,8 +342,62 @@ describe(CONSTRUCTION_PREPROCESS_ENDPOINT, () => {
       });
     });
 
+    test('Should fail if MultiAsset policy id is not a hex string', async () => {
+      const invalidPolicy = 'thisIsANonHexString';
+
+      const operations = modifyMAOperation(invalidPolicy)(CONSTRUCTION_PAYLOADS_REQUEST_WITH_MA.operations);
+
+      const response = await server.inject({
+        method: 'post',
+        url: CONSTRUCTION_PREPROCESS_ENDPOINT,
+        // eslint-disable-next-line no-magic-numbers
+        payload: generateProcessPayload({
+          blockchain: 'cardano',
+          network: 'mainnet',
+          relativeTtl: 100,
+          operations
+        })
+      });
+      expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(response.json()).toEqual({
+        code: 4009,
+        details: {
+          message: `PolicyId ${invalidPolicy} is not valid`
+        },
+        message: invalidOperationErrorMessage,
+        retriable: false
+      });
+    });
+
     test('Should fail if MultiAsset symbol longer than expected', async () => {
       const invalidSymbol = new Array(ASSET_NAME_LENGTH + 2).join('0');
+
+      const operations = modifyMAOperation(undefined, invalidSymbol)(CONSTRUCTION_PAYLOADS_REQUEST_WITH_MA.operations);
+
+      const response = await server.inject({
+        method: 'post',
+        url: CONSTRUCTION_PREPROCESS_ENDPOINT,
+        // eslint-disable-next-line no-magic-numbers
+        payload: generateProcessPayload({
+          blockchain: 'cardano',
+          network: 'mainnet',
+          relativeTtl: 100,
+          operations
+        })
+      });
+      expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(response.json()).toEqual({
+        code: 4009,
+        details: {
+          message: `Token name ${invalidSymbol} is not valid`
+        },
+        message: invalidOperationErrorMessage,
+        retriable: false
+      });
+    });
+
+    test('Should fail if MultiAsset symbol is not a hex string', async () => {
+      const invalidSymbol = 'thisIsANonHexString';
 
       const operations = modifyMAOperation(undefined, invalidSymbol)(CONSTRUCTION_PAYLOADS_REQUEST_WITH_MA.operations);
 


### PR DESCRIPTION
# Description

Adds validations to check token symbol and policy to be a hex string and the corresponding automated tests.

# References

Closes #299

