### PR TITLE
test: fix test for invalid non hex ma policy

### DIFF
--- a/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
@@ -653,7 +653,7 @@ describe('Invalid request with MultiAssets', () => {
   });
 
   test('Should fail if MultiAsset policy id is not a hex string', async () => {
-    const invalidPolicy = 'thisIsANonHexString';
+    const invalidPolicy = new Array(POLICY_ID_LENGTH + 1).join('w');
     const { operations, ...restPayload } = CONSTRUCTION_PAYLOADS_REQUEST_WITH_MA;
     const payload = {
       operations: modifyMAOperation(invalidPolicy)(operations),

--- a/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
@@ -343,7 +343,7 @@ describe(CONSTRUCTION_PREPROCESS_ENDPOINT, () => {
     });
 
     test('Should fail if MultiAsset policy id is not a hex string', async () => {
-      const invalidPolicy = 'thisIsANonHexString';
+      const invalidPolicy = new Array(POLICY_ID_LENGTH + 1).join('w');
 
       const operations = modifyMAOperation(invalidPolicy)(CONSTRUCTION_PAYLOADS_REQUEST_WITH_MA.operations);
 


### PR DESCRIPTION
# Description

Tests for invalid non-hex string multi assets policy weren't being done ok because they didn't satisfy the policy length validation.

# Testing

Run server tests.

