### PR TITLE
refactor: refact multi assets data mapper

### DIFF
--- a/cardano-rosetta-server/src/server/controllers/account-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/account-controller.ts
@@ -29,13 +29,13 @@ const configure = (
         if (cardanoService.getEraAddressType(accountAddress) === null)
           throw ErrorFactory.invalidAddressError(accountAddress);
         logger.info(`[accountBalance] Looking for block: ${accountBalanceRequest.block_identifier || 'latest'}`);
-        const blockUtxos = await blockService.findBalanceDataByAddressAndBlock(
+        const blockBalanceData = await blockService.findBalanceDataByAddressAndBlock(
           logger,
           accountAddress,
           accountBalanceRequest.block_identifier?.index,
           accountBalanceRequest.block_identifier?.hash
         );
-        const toReturn = mapToAccountBalanceResponse(blockUtxos);
+        const toReturn = mapToAccountBalanceResponse(blockBalanceData);
         logger.debug(toReturn, '[accountBalance] About to return ');
         return toReturn;
       },

--- a/cardano-rosetta-server/src/server/db/blockchain-repository.ts
+++ b/cardano-rosetta-server/src/server/db/blockchain-repository.ts
@@ -84,7 +84,8 @@ export interface BlockchainRepository {
   findUtxoByAddressAndBlock(logger: Logger, address: string, blockHash: string): Promise<Utxo[]>;
 
   /**
-   * Returns an array containing all multi asset balances for address till block identified by blockIdentifier if present, else the last
+   * Returns an array containing all multi asset balances for the provided address till block identified by
+   * blockIdentifier is present. Otherwise, it returns the last one.
    * @param address account's address to count balance
    * @param blockIdentifier block information, when value is not undefined balance should be count till requested block
    */

--- a/cardano-rosetta-server/src/server/db/blockchain-repository.ts
+++ b/cardano-rosetta-server/src/server/db/blockchain-repository.ts
@@ -10,7 +10,8 @@ import {
   Token,
   Transaction,
   TransactionInOut,
-  Utxo
+  Utxo,
+  MaBalance
 } from '../models';
 import { hexStringToBuffer, hexFormatter } from '../utils/formatters';
 import Queries, {
@@ -24,7 +25,8 @@ import Queries, {
   FindTransactionsInputs,
   FindTransactionsOutputs,
   FindTransactionWithdrawals,
-  FindUtxo
+  FindUtxo,
+  FindMaBalance
 } from './queries/blockchain-queries';
 
 export interface BlockchainRepository {
@@ -81,6 +83,12 @@ export interface BlockchainRepository {
    */
   findUtxoByAddressAndBlock(logger: Logger, address: string, blockHash: string): Promise<Utxo[]>;
 
+  /**
+   * Returns an array containing all multi asset balances for address till block identified by blockIdentifier if present, else the last
+   * @param address account's address to count balance
+   * @param blockIdentifier block information, when value is not undefined balance should be count till requested block
+   */
+  findMultiAssetByAddressAndBlock(logger: Logger, address: string, blockHash: string): Promise<MaBalance[]>;
   /**
    * Returns the balance for address till block identified by blockIdentifier if present, else the last
    * @param address account's address to count balance
@@ -493,6 +501,19 @@ export const configure = (databaseInstance: Pool): BlockchainRepository => ({
       name: utxo.name ? hexFormatter(utxo.name) : utxo.name,
       policy: utxo.policy ? hexFormatter(utxo.policy) : utxo.policy,
       quantity: utxo.quantity
+    }));
+  },
+  async findMultiAssetByAddressAndBlock(logger: Logger, address, blockHash): Promise<MaBalance[]> {
+    const parameters = [address, hexStringToBuffer(blockHash)];
+    const balancesResult: QueryResult<FindMaBalance> = await databaseInstance.query(
+      Queries.findMaBalanceByAddressAndBlock,
+      parameters
+    );
+    logger.debug(`[findMultiAssetByAddressAndBlock] Found balances for ${balancesResult.rowCount} multi assets`);
+    return balancesResult.rows.map(multiAssetBalance => ({
+      name: multiAssetBalance?.name && hexFormatter(multiAssetBalance.name),
+      policy: multiAssetBalance?.policy && hexFormatter(multiAssetBalance.policy),
+      value: multiAssetBalance.value
     }));
   },
   async findBalanceByAddressAndBlock(logger: Logger, address, blockHash): Promise<string> {

--- a/cardano-rosetta-server/src/server/models.ts
+++ b/cardano-rosetta-server/src/server/models.ts
@@ -49,6 +49,12 @@ export interface Utxo {
   quantity?: string;
 }
 
+export interface MaBalance {
+  name: string;
+  policy: string;
+  value: string;
+}
+
 export interface TransactionInOut {
   id: number;
   address: string;
@@ -108,6 +114,7 @@ export interface Network {
 export interface BlockUtxos {
   block: Block;
   utxos: Utxo[];
+  maBalances: MaBalance[];
 }
 
 export interface BalanceAtBlock {

--- a/cardano-rosetta-server/src/server/services/block-service.ts
+++ b/cardano-rosetta-server/src/server/services/block-service.ts
@@ -160,13 +160,15 @@ const configure = (repository: BlockchainRepository, cardanoService: CardanoServ
       };
     }
     const utxoDetails = await repository.findUtxoByAddressAndBlock(logger, address, block.hash);
+    const maBalances = await repository.findMultiAssetByAddressAndBlock(logger, address, block.hash);
     logger.debug(
       utxoDetails,
       `[findBalanceDataByAddressAndBlock] Found ${utxoDetails.length} utxo details for address ${address}`
     );
     return {
       block,
-      utxos: utxoDetails
+      utxos: utxoDetails,
+      maBalances
     };
   },
   findTransaction(logger, transactionHash, blockNumber, blockHash) {

--- a/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
@@ -30,7 +30,8 @@ describe('Data Mapper', () => {
             name: '',
             policy: ''
           }
-        ]
+        ],
+        maBalances: []
       };
       const mapped = mapToAccountBalanceResponse(blockUtxos);
       expect(mapped).toEqual({


### PR DESCRIPTION
# Description

Improves a hard to follow algorithm done at the moment of multi assets implementation for `account/balance` response.

# Proposed Solution

In order to reduce the algorithm logic when mapping utxo data,  a query for multi assets balances was added. Besides that, some part of the algorithm's complexity is left since it's needed for `coins` object.

# References

Closes #288.

