### PR TITLE
feat: try multiple eras when sending a transaction

### DIFF
--- a/cardano-rosetta-server/src/server/utils/cardano/cli/cardanonode-cli.ts
+++ b/cardano-rosetta-server/src/server/utils/cardano/cli/cardanonode-cli.ts
@@ -60,10 +60,10 @@ export const configure = (
         logger.info('[submitTransaction] transaction successfully sent', stdout.toString());
         return;
       } catch (error) {
+        logger.error(error, '[submitTransaction] Command failed');
         if (isWrongEra(error.stderr.toString())) {
           logger.debug(`[submitTransaction] Era mismatch when using era ${era}`);
         } else {
-          logger.error(error, '[submitTransaction] Command failed');
           throw new Error(error.stderr.toString());
         }
       } finally {

--- a/cardano-rosetta-server/src/server/utils/cardano/cli/cardanonode-cli.ts
+++ b/cardano-rosetta-server/src/server/utils/cardano/cli/cardanonode-cli.ts
@@ -13,28 +13,62 @@ export interface CardanoCli {
   submitTransaction(logger: Logger, signedTransaction: string, isMainnet: boolean): Promise<void>;
 }
 
-export const configure = (cardanoCliPath: string, networkMagic: number): CardanoCli => ({
+const SUPPORTED_ERAS = ['Tx MaryEra', 'TxSignedShelley'];
+
+/**
+ * This function returns true if DecoderErrorDeserialiseFailure is thrown.
+ *
+ * It's not the best way to detect if an era mismatch but it has been agreed
+ * it's the simplest one we can do.
+ *
+ * @param errorMessage
+ */
+const isWrongEra = (errorMessage: string): boolean => errorMessage.includes('DecoderErrorDeserialiseFailure');
+
+export type ProcessExecutorResult = execa.ExecaChildProcess;
+
+export type ProcessExecutor = (file: string, arguments_?: readonly string[]) => ProcessExecutorResult;
+
+const defaultExecutor: ProcessExecutor = (file: string, arguments_) => execa(file, arguments_);
+
+export const configure = (
+  cardanoCliPath: string,
+  networkMagic: number,
+  processExecutor = defaultExecutor
+): CardanoCli => ({
   async submitTransaction(logger, signedTransaction, isMainnet): Promise<void> {
-    logger.info(`[submitTransaction] About to create temp file for transaction ${signedTransaction}`);
-    const file = await tempWrite(`{
-      "type": "Tx MaryEra",
-      "description": "",
-      "cborHex": "${signedTransaction}"
-    }`);
-    logger.info(`[submitTransaction] File created at ${file}`);
-    try {
-      // `--testnet-magic` flag is used even if it's mainnet as we are using the proper networkMagic
-      logger.info(`[submitTransaction] Invoking cardano-cli at ${cardanoCliPath} using ${networkMagic} networkMagic`);
-      const commonParameters = ['transaction', 'submit', '--tx-file', file];
-      const parameters = isMainnet
-        ? commonParameters.concat('--mainnet')
-        : commonParameters.concat('--testnet-magic', networkMagic.toString());
-      const { stderr, failed } = await execa(cardanoCliPath, parameters);
-      if (failed) {
-        throw new Error(stderr.toString());
+    for (const era of SUPPORTED_ERAS) {
+      logger.info(`[submitTransaction] About to create temp file for transaction ${signedTransaction}`);
+      const cardanoCliFileContent = `{
+        "type": "${era}",
+        "description": "",
+        "cborHex": "${signedTransaction}"
+      }`;
+      logger.info(cardanoCliFileContent, '[submitTransaction] cardano-cli file');
+      const file = await tempWrite(cardanoCliFileContent);
+      logger.info(`[submitTransaction] File created at ${file}`);
+      try {
+        // `--testnet-magic` flag is used even if it's mainnet as we are using the proper networkMagic
+        logger.info(`[submitTransaction] Invoking cardano-cli at ${cardanoCliPath} using ${networkMagic} networkMagic`);
+        const commonParameters = ['transaction', 'submit', '--tx-file', file];
+        const parameters = isMainnet
+          ? commonParameters.concat('--mainnet')
+          : commonParameters.concat('--testnet-magic', networkMagic.toString());
+        const { stdout } = await processExecutor(cardanoCliPath, parameters);
+        logger.info('[submitTransaction] transaction successfully sent', stdout.toString());
+        return;
+      } catch (error) {
+        if (isWrongEra(error.stderr.toString())) {
+          logger.error(`[submitTransaction] Era mismatch when using era ${era}`);
+        } else {
+          logger.error(error, '[submitTransaction] Command failed');
+          throw new Error(error.stderr.toString());
+        }
+      } finally {
+        await fs.promises.unlink(file);
       }
-    } finally {
-      await fs.promises.unlink(file);
     }
+    // eslint-disable-next-line quotes
+    throw new Error("Transaction wasn't processed. Era not supported.");
   }
 });

--- a/cardano-rosetta-server/src/server/utils/cardano/cli/cardanonode-cli.ts
+++ b/cardano-rosetta-server/src/server/utils/cardano/cli/cardanonode-cli.ts
@@ -20,7 +20,6 @@ const wrongErraDetectRegex = /The era of the node and the tx do not match|Decode
  * This function returns true if DecoderErrorDeserialiseFailure is thrown.
  *
  * It's not the best way to detect if an era mismatch but it avoids a race condition
- * it's the simplest one we can do.
  *
  * @param errorMessage
  */

--- a/cardano-rosetta-server/test/unit/utils/cardano/cli/cardanonode-cli.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/cardano/cli/cardanonode-cli.test.ts
@@ -1,0 +1,92 @@
+import { Logger } from 'fastify';
+import { configure } from '../../../../../src/server/utils/cardano/cli/cardanonode-cli';
+
+const logger: Logger = {
+  info: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+  fatal: jest.fn(),
+  warn: jest.fn(),
+  trace: jest.fn()
+};
+
+const WRONG_ERA_ERROR =
+  'TextEnvelope decode error: DecoderErrorDeserialiseFailure "Shelley Tx" (DeserialiseFailure 102 "expected word")';
+describe('CardanoNode CLI', () => {
+  it('Should retry if an era mismatch', async () => {
+    const executor = jest.fn();
+    executor
+      .mockRejectedValueOnce({
+        stderr: WRONG_ERA_ERROR
+      })
+      .mockResolvedValueOnce({
+        stdout: 'transactionhash',
+        failed: false
+      });
+    // eslint-disable-next-line no-magic-numbers
+    const cli = configure('/path', 3, executor);
+    await cli.submitTransaction(logger, 'deadbeefdeadbeef', true);
+    // eslint-disable-next-line no-magic-numbers
+    expect(executor).toBeCalledTimes(2);
+  });
+
+  it('Should throw an error if eras are not supported', async () => {
+    const executor = jest.fn();
+    executor.mockRejectedValue({
+      stderr: WRONG_ERA_ERROR
+    });
+    // eslint-disable-next-line no-magic-numbers
+    const cli = configure('/path', 3, executor);
+    await expect(cli.submitTransaction(logger, 'deadbeefdeadbeef', true)).rejects.toThrow(
+      // eslint-disable-next-line quotes
+      "Transaction wasn't processed. Era not supported."
+    );
+    // eslint-disable-next-line no-magic-numbers
+    expect(executor).toBeCalledTimes(2);
+  });
+
+  it('Should execute a single call if no errors', async () => {
+    const executor = jest.fn();
+    executor.mockResolvedValueOnce({
+      stdout: 'transactionhash'
+    });
+    // eslint-disable-next-line no-magic-numbers
+    const cli = configure('/path', 3, executor);
+    await cli.submitTransaction(logger, 'deadbeefdeadbeef', true);
+    // eslint-disable-next-line no-magic-numbers
+    expect(executor).toBeCalledTimes(1);
+  });
+
+  it('Should throw and error and fail is not related to era mismatch', async () => {
+    const executor = jest.fn();
+    const error =
+      'Error while submitting tx: ApplyTxError [LedgerFailure (UtxowFailure (UtxoFailure (ValueNotConservedUTxO (Value 20000000 (fromList [(PolicyID {policyID = ScriptHash "9e2a4681f2e26df0312e4960584a2c56e1c1206d4d621a4648f0ff97"},fromList [("cats",5),("dogs",5)])])) (Value 20000000 (fromList [(PolicyID {policyID = ScriptHash "9e2a4681f2e26df0312e4960584a2c56e1c1206d4d621a4648f0ff97"},fromList [("",5),("\\202",5)])])))))]]}';
+    executor.mockRejectedValue({
+      stderr: error
+    });
+    // eslint-disable-next-line no-magic-numbers
+    const cli = configure('/path', 3, executor);
+    await expect(cli.submitTransaction(logger, 'deadbeefdeadbeef', true)).rejects.toThrow(error);
+    // eslint-disable-next-line no-magic-numbers
+    expect(executor).toBeCalledTimes(1);
+  });
+
+  it('Should throw if command fails after an era mismatch', async () => {
+    const executor = jest.fn();
+    const error =
+      'Error while submitting tx: ApplyTxError [LedgerFailure (UtxowFailure (UtxoFailure (ValueNotConservedUTxO (Value 20000000 (fromList [(PolicyID {policyID = ScriptHash "9e2a4681f2e26df0312e4960584a2c56e1c1206d4d621a4648f0ff97"},fromList [("cats",5),("dogs",5)])])) (Value 20000000 (fromList [(PolicyID {policyID = ScriptHash "9e2a4681f2e26df0312e4960584a2c56e1c1206d4d621a4648f0ff97"},fromList [("",5),("\\202",5)])])))))]]}';
+    executor
+      .mockRejectedValueOnce({
+        stderr:
+          'TextEnvelope decode error: DecoderErrorDeserialiseFailure "Shelley Tx" (DeserialiseFailure 102 "expected word")'
+      })
+      .mockRejectedValue({
+        stderr: error
+      });
+    // eslint-disable-next-line no-magic-numbers
+    const cli = configure('/path', 3, executor);
+    await expect(cli.submitTransaction(logger, 'deadbeefdeadbeef', true)).rejects.toThrow(error);
+    // eslint-disable-next-line no-magic-numbers
+    expect(executor).toBeCalledTimes(2);
+  });
+});

--- a/cardano-rosetta-server/test/unit/utils/cardano/cli/cardanonode-cli.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/cardano/cli/cardanonode-cli.test.ts
@@ -57,7 +57,7 @@ describe('CardanoNode CLI', () => {
     expect(executor).toBeCalledTimes(1);
   });
 
-  it('Should throw and error and fail is not related to era mismatch', async () => {
+  it('Should throw errors unrelated to era mismatch', async () => {
     const executor = jest.fn();
     const error =
       'Error while submitting tx: ApplyTxError [LedgerFailure (UtxowFailure (UtxoFailure (ValueNotConservedUTxO (Value 20000000 (fromList [(PolicyID {policyID = ScriptHash "9e2a4681f2e26df0312e4960584a2c56e1c1206d4d621a4648f0ff97"},fromList [("cats",5),("dogs",5)])])) (Value 20000000 (fromList [(PolicyID {policyID = ScriptHash "9e2a4681f2e26df0312e4960584a2c56e1c1206d4d621a4648f0ff97"},fromList [("",5),("\\202",5)])])))))]]}';


### PR DESCRIPTION
# Description

This PR allows sending transactions to both Shelley and Mary

# Proposed Solution

Based on a discussion with @rhyslbw there isn't a clean way detect which era is the node running using the `cardano-cli` and, therefore, to update the tx encoding to be sent to it when submitting a transactions. That being said, it was defined to try different eras and fall-back to different ones if a `DecoderErrorDeserialiseFailure` error is found.

# Important Changes Introduced

Transaction sending is affected by this change

# Testing

- Testing this PR is quite complex as it's required to have a way to this this with different eras. We executed this on a `mary` network and then changed the container (edited the file and then restarted) to specify shelley as default one making the fall back to happen all the time.
- All the test cases have been automated although the CLI is mocked so it should be manually tested as well

A test execution in `testnet` is still needed.

