### PR TITLE
Upgrade to Rosetta 1.4.10

### DIFF
--- a/cardano-rosetta-server/README.md
+++ b/cardano-rosetta-server/README.md
@@ -37,6 +37,8 @@ CARDANO_NODE_SOCKET_PATH=/tmp/node.socket
 PAGE_SIZE=25
 # relative ttl to be used if any is sent during the request
 DEFAULT_RELATIVE_TTL=1000
+# Exemption types file path
+EXEMPTION_TYPES_PATH="/etc/node/exemptions.json"
 ```
 
 ### Install packages from offline cache

--- a/cardano-rosetta-server/config/exemptions.json
+++ b/cardano-rosetta-server/config/exemptions.json
@@ -1,0 +1,11 @@
+[
+{
+    "exemption_type": "greater_or_equal"
+},
+{
+    "exemption_type": "less_or_equal"
+},
+{
+    "exemption_type": "dynamic"
+}
+]

--- a/cardano-rosetta-server/src/server/controllers/account-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/account-controller.ts
@@ -60,12 +60,12 @@ const configure = (
           throw ErrorFactory.invalidAddressError(accountAddress);
         currencies?.forEach(({ symbol, metadata }) => {
           if (!isTokenNameValid(symbol)) throw ErrorFactory.invalidTokenNameError(`Given name is ${symbol}`);
-          if (!isPolicyIdValid(metadata.policyId))
+          if (symbol !== ADA && !isPolicyIdValid(metadata.policyId))
             throw ErrorFactory.invalidPolicyIdError(`Given policy id is ${metadata.policyId}`);
         });
-        // if ADA is requested as currency then all coins will be returned
+        // if ADA is requested then all coins will be returned
         const currenciesRequested =
-          currencies && !currencies.map(currency => currency.symbol).includes(ADA) ? currencies : [];
+          currencies && !currencies.map(currency => currency.symbol).some(s => s === ADA) ? currencies : [];
         const blockUtxos = await blockService.findCoinsDataByAddress(logger, accountAddress, currenciesRequested);
         const toReturn = mapToAccountCoinsResponse(blockUtxos);
         logger.debug(toReturn, '[accountCoins] About to return ');

--- a/cardano-rosetta-server/src/server/controllers/account-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/account-controller.ts
@@ -56,7 +56,6 @@ const configure = (
         logger.debug({ accountBalanceRequest: request.body }, '[accountCoins] Request received');
         if (cardanoService.getEraAddressType(accountAddress) === null)
           throw ErrorFactory.invalidAddressError(accountAddress);
-        logger.info('[accountCoins] Looking for latest block');
         const blockUtxos = await blockService.findCoinsDataByAddress(logger, accountAddress);
         const toReturn = mapToAccountCoinsResponse(blockUtxos);
         logger.debug(toReturn, '[accountCoins] About to return ');

--- a/cardano-rosetta-server/src/server/controllers/account-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/account-controller.ts
@@ -3,13 +3,16 @@ import { withNetworkValidation } from '../controllers/controllers-helper';
 import { BlockService } from '../services/block-service';
 import { CardanoService } from '../services/cardano-services';
 import { NetworkService } from '../services/network-service';
-import { mapToAccountBalanceResponse } from '../utils/data-mapper';
+import { mapToAccountBalanceResponse, mapToAccountCoinsResponse } from '../utils/data-mapper';
 import { ErrorFactory } from '../utils/errors';
 
 export interface AccountController {
   accountBalance(
     request: FastifyRequest<unknown, unknown, unknown, unknown, Components.Schemas.AccountBalanceRequest>
   ): Promise<Components.Schemas.AccountBalanceResponse | Components.Schemas.Error>;
+  accountCoins(
+    request: FastifyRequest<unknown, unknown, unknown, unknown, Components.Schemas.AccountCoinsRequest>
+  ): Promise<Components.Schemas.AccountCoinsResponse | Components.Schemas.Error>;
 }
 
 const configure = (
@@ -37,6 +40,26 @@ const configure = (
         );
         const toReturn = mapToAccountBalanceResponse(blockBalanceData);
         logger.debug(toReturn, '[accountBalance] About to return ');
+        return toReturn;
+      },
+      request.log,
+      networkService
+    ),
+  accountCoins: async request =>
+    withNetworkValidation(
+      request.body.network_identifier,
+      request,
+      async () => {
+        const logger = request.log;
+        const accountCoinsRequest = request.body;
+        const accountAddress = accountCoinsRequest.account_identifier.address;
+        logger.debug({ accountBalanceRequest: request.body }, '[accountCoins] Request received');
+        if (cardanoService.getEraAddressType(accountAddress) === null)
+          throw ErrorFactory.invalidAddressError(accountAddress);
+        logger.info('[accountCoins] Looking for latest block');
+        const blockUtxos = await blockService.findCoinsDataByAddress(logger, accountAddress);
+        const toReturn = mapToAccountCoinsResponse(blockUtxos);
+        logger.debug(toReturn, '[accountCoins] About to return ');
         return toReturn;
       },
       request.log,

--- a/cardano-rosetta-server/src/server/controllers/construction-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/construction-controller.ts
@@ -108,9 +108,11 @@ const configure = (
           throw ErrorFactory.addressGenerationError();
         }
         logger.info(`[constructionDerive] new address is ${address}`);
-
         return {
-          address
+          // eslint-disable-next-line camelcase
+          account_identifier: {
+            address
+          }
         };
       },
       request.log,

--- a/cardano-rosetta-server/src/server/controllers/network-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/network-controller.ts
@@ -74,7 +74,7 @@ const configure = (networkService: NetworkService, cardanoNode: CardanoNode): Ne
               .sort((error1, error2) => error1.code - error2.code),
             historical_balance_lookup: true,
             call_methods: [],
-            balance_exemptions: [],
+            balance_exemptions: networkService.getExemptionTypes(),
             mempool_coins: false
           }
         };

--- a/cardano-rosetta-server/src/server/controllers/network-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/network-controller.ts
@@ -72,7 +72,10 @@ const configure = (networkService: NetworkService, cardanoNode: CardanoNode): Ne
               .map(fn => fn())
               // Return them sorted by code
               .sort((error1, error2) => error1.code - error2.code),
-            historical_balance_lookup: true
+            historical_balance_lookup: true,
+            call_methods: [],
+            balance_exemptions: [],
+            mempool_coins: false
           }
         };
         logger.info('[networkOptions] All network options has been successfully fetched.');

--- a/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
+++ b/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
@@ -247,7 +247,7 @@ LEFT JOIN tx_in ON
   tx_out.index::smallint = tx_in.tx_out_index::smallint 
 LEFT JOIN tx as tx_in_tx ON 
   tx_in_tx.id = tx_in.tx_in_id AND
-  tx_in_tx.block_id <= (select id from block where hash = $2) 
+  tx_in_tx.block_id <= (select id from block where hash = $2)
 JOIN tx AS tx_out_tx ON
   tx_out_tx.id = tx_out.tx_id AND
   tx_out_tx.block_id <= (select id from block where hash = $2)
@@ -283,21 +283,22 @@ SELECT
     ma_tx_out.policy, ma_tx_out.name
   `;
 
-const findBalanceByAddressAndBlock = `SELECT (SELECT COALESCE(SUM(r.amount),0) 
-  FROM reward r
-  JOIN stake_address ON 
-    stake_address.id = r.addr_id
-  JOIN block ON
-    block.id = r.block_id
-  WHERE stake_address.view = $1
-  AND block.id <= (SELECT id FROM block WHERE hash = $2))- 
-  (SELECT COALESCE(SUM(w.amount),0) 
-  FROM withdrawal w
-  JOIN tx ON tx.id = w.tx_id AND 
-    tx.block_id <= (SELECT id FROM block WHERE hash = $2)
-  JOIN stake_address ON stake_address.id = w.addr_id
-  WHERE stake_address.view = $1) 
-  AS balance
+const findBalanceByAddressAndBlock = `
+  SELECT (SELECT COALESCE(SUM(r.amount),0) 
+      FROM reward r
+    JOIN stake_address ON 
+        stake_address.id = r.addr_id
+    JOIN block ON
+        block.id = r.block_id
+    WHERE stake_address.view = $1
+    AND block.id <= (SELECT id FROM block WHERE hash = $2))- 
+    (SELECT COALESCE(SUM(w.amount),0) 
+    FROM withdrawal w
+    JOIN tx ON tx.id = w.tx_id AND 
+      tx.block_id <= (SELECT id FROM block WHERE hash = $2)
+    JOIN stake_address ON stake_address.id = w.addr_id
+    WHERE stake_address.view = $1) 
+    AS balance
 `;
 
 const Queries = {

--- a/cardano-rosetta-server/src/server/models.ts
+++ b/cardano-rosetta-server/src/server/models.ts
@@ -114,6 +114,9 @@ export interface Network {
 export interface BlockUtxos {
   block: Block;
   utxos: Utxo[];
+}
+
+export interface BlockUtxosMultiAssets extends BlockUtxos {
   maBalances: MaBalance[];
 }
 

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1878,7 +1878,7 @@
       "ConstructionDeriveResponse": {
         "description": "ConstructionDeriveResponse is returned by the `/construction/derive` endpoint.",
         "type": "object",
-        "required": ["address"],
+        "required": ["account_identifier"],
         "properties": {
           "address": {
             "type": "string",
@@ -2042,7 +2042,7 @@
       "ConstructionParseResponse": {
         "description": "ConstructionParseResponse contains an array of operations that occur in a transaction blob. This should match the array of operations provided to `/construction/preprocess` and `/construction/payloads`.",
         "type": "object",
-        "required": ["operations", "signers"],
+        "required": ["operations", "account_identifier_signers"],
         "properties": {
           "operations": {
             "type": "array",

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1583,7 +1583,7 @@
       "AccountCoinsRequest": {
         "description": "AccountCoinsRequest is utilized to make a request on the /account/coins endpoint.",
         "type": "object",
-        "required": ["network_identifier", "account_identifier", "include_mempool"],
+        "required": ["network_identifier", "account_identifier"],
         "properties": {
           "network_identifier": {
             "$ref": "#/components/schemas/NetworkIdentifier"

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1806,7 +1806,7 @@
       "ConstructionMetadataRequest": {
         "description": "A ConstructionMetadataRequest is utilized to get information required to construct a transaction. The Options object used to specify which metadata to return is left purposely unstructured to allow flexibility for implementers. Options is not required in the case that there is network-wide metadata of interest. Optionally, the request can also include an array of PublicKeys associated with the AccountIdentifiers returned in ConstructionPreprocessResponse.",
         "type": "object",
-        "required": ["network_identifier"],
+        "required": ["network_identifier", "options"],
         "properties": {
           "network_identifier": {
             "$ref": "#/components/schemas/NetworkIdentifier"
@@ -1950,7 +1950,7 @@
       "ConstructionPayloadsRequest": {
         "description": "ConstructionPayloadsRequest is the request to `/construction/payloads`. It contains the network, a slice of operations, and arbitrary metadata that was returned by the call to `/construction/metadata`. Optionally, the request can also include an array of PublicKeys associated with the AccountIdentifiers returned in ConstructionPreprocessResponse.",
         "type": "object",
-        "required": ["network_identifier", "operations"],
+        "required": ["network_identifier", "operations", "metadata"],
         "properties": {
           "network_identifier": {
             "$ref": "#/components/schemas/NetworkIdentifier"
@@ -1962,7 +1962,11 @@
             }
           },
           "metadata": {
-            "type": "object"
+            "type": "object",
+            "required": ["ttl"],
+            "properties": {
+              "ttl": { "type": "string" }
+            }
           },
           "public_keys": {
             "type": "array",

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.2",
   "info": {
-    "version": "1.4.4",
+    "version": "1.4.10",
     "title": "Rosetta",
     "description": "Build Once. Integrate Your Blockchain Everywhere.",
     "license": {
@@ -292,7 +292,7 @@
     },
     "/account/balance": {
       "post": {
-        "summary": "Get an Account Balance",
+        "summary": "Get an Account's Balance",
         "description": "Get an array of all AccountBalances for an AccountIdentifier and the BlockIdentifier at which the balance lookup was performed. The BlockIdentifier must always be returned because some consumers of account balance data need to know specifically at which block the balance was calculated to compare balances they compute from operations with the balance returned by the node. It is important to note that making a balance request for an account without populating the SubAccountIdentifier should not result in the balance of all possible SubAccountIdentifiers being returned. Rather, it should result in the balance pertaining to no SubAccountIdentifiers being returned (sometimes called the liquid balance). To get all balances associated with an account, it may be necessary to perform multiple balance requests with unique AccountIdentifiers. It is also possible to perform a historical balance lookup (if the server supports it) by passing in an optional BlockIdentifier.",
         "operationId": "accountBalance",
         "tags": ["Account"],
@@ -313,6 +313,46 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AccountBalanceResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/account/coins": {
+      "post": {
+        "summary": "Get an Account's Unspent Coins",
+        "description": "Get an array of all unspent coins for an AccountIdentifier and the BlockIdentifier at which the lookup was performed. If your implementation does not support coins (i.e. it is for an account-based blockchain), you do not need to implement this endpoint. If you implementation does support coins (i.e. it is fro a UTXO-based blockchain), you MUST also complete the `/account/balance` endpoint. It is important to note that making a coins request for an account without populating the SubAccountIdentifier should not result in the coins of all possible SubAccountIdentifiers being returned. Rather, it should result in the coins pertaining to no SubAccountIdentifiers being returned. To get all coins associated with an account, it may be necessary to perform multiple coin requests with unique AccountIdentifiers. Optionally, an implementation may choose to support updating an AccountIdentifier's unspent coins based on the contents of the mempool. Note, using this functionality breaks any guarantee of idempotency.",
+        "operationId": "accountCoins",
+        "tags": ["Account"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountCoinsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountCoinsResponse"
                 }
               }
             }
@@ -649,6 +689,126 @@
           }
         }
       }
+    },
+    "/call": {
+      "post": {
+        "summary": "Make a Network-Specific Procedure Call",
+        "description": "Call invokes an arbitrary, network-specific procedure call with network-specific parameters. The guidance for what this endpoint should or could do is purposely left vague. In Ethereum, this could be used to invoke `eth_call` to implement an entire Rosetta API interface for some smart contract that is not parsed by the implementation creator (like a DEX). This endpoint could also be used to provide access to data that does not map to any Rosetta models instead of requiring an integrator to use some network-specific SDK and call some network-specific endpoint (like surfacing staking parameters). Call is NOT a replacement for implementing Rosetta API endpoints or mapping network-specific data to Rosetta models. Rather, it enables developers to build additional Rosetta API interfaces for things they care about without introducing complexity into a base-level Rosetta implementation. Simply put, imagine that the average integrator will use layered Rosetta API implementations that each surfaces unique data.",
+        "operationId": "call",
+        "tags": ["Call"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CallRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/events/blocks": {
+      "post": {
+        "summary": "[INDEXER] Get a range of BlockEvents",
+        "description": "`/events/blocks` allows the caller to query a sequence of BlockEvents indicating which blocks were added and removed from storage to reach the current state. Following BlockEvents allows lightweight clients to update their state without needing to implement their own syncing logic (like finding the common parent in a reorg). `/events/blocks` is considered an \"indexer\" endpoint and Rosetta implementations are not required to complete it to adhere to the Rosetta spec. However, any Rosetta \"indexer\" MUST support this endpoint.",
+        "operationId": "eventsBlocks",
+        "tags": ["Events"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventsBlocksRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventsBlocksResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/transactions": {
+      "post": {
+        "summary": "[INDEXER] Search for Transactions",
+        "description": "`/search/transactions` allows the caller to search for transactions that meet certain conditions. Some conditions include matching a transaction hash, containing an operation with a certain status, or containing an operation that affects a certain account. `/search/transactions` is considered an \"indexer\" endpoint and Rosetta implementations are not required to complete it to adhere to the Rosetta spec. However, any Rosetta \"indexer\" MUST support this endpoint.",
+        "operationId": "searchTransactions",
+        "tags": ["Search"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchTransactionsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchTransactionsResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -839,6 +999,12 @@
               "$ref": "#/components/schemas/Operation"
             }
           },
+          "related_transactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RelatedTransaction"
+            }
+          },
           "metadata": {
             "description": "Transactions that are related to other transactions (like a cross-shard transaction) should include the tranaction_identifier of these transactions in the metadata.",
             "type": "object",
@@ -850,15 +1016,15 @@
         }
       },
       "Operation": {
-        "description": "Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction.",
+        "description": "Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction. Operations are used both to represent on-chain data (Data API) and to construct new transactions (Construction API), creating a standard interface for reading and writing to blockchains.",
         "type": "object",
-        "required": ["operation_identifier", "type", "status"],
+        "required": ["operation_identifier", "type"],
         "properties": {
           "operation_identifier": {
             "$ref": "#/components/schemas/OperationIdentifier"
           },
           "related_operations": {
-            "description": "Restrict referenced related_operations to identifier indexes < the current operation_identifier.index. This ensures there exists a clear DAG-structure of relations. Since operations are one-sided, one could imagine relating operations in a single transfer or linking operations in a call tree.",
+            "description": "Restrict referenced related_operations to identifier indices < the current operation_identifier.index. This ensures there exists a clear DAG-structure of relations. Since operations are one-sided, one could imagine relating operations in a single transfer or linking operations in a call tree.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/OperationIdentifier"
@@ -873,12 +1039,12 @@
             ]
           },
           "type": {
-            "description": "The network-specific type of the operation. Ensure that any type that can be returned here is also specified in the NetworkOptionsResponse. This can be very useful to downstream consumers that parse all block data.",
+            "description": "Type is the network-specific type of the operation. Ensure that any type that can be returned here is also specified in the NetworkOptionsResponse. This can be very useful to downstream consumers that parse all block data.",
             "type": "string",
             "example": "Transfer"
           },
           "status": {
-            "description": "The network-specific status of the operation. Status is not defined on the transaction object because blockchains with smart contracts may have transactions that partially apply. Blockchains with atomic transactions (all operations succeed or all operations fail) will have the same status for each operation.",
+            "description": "Status is the network-specific status of the operation. Status is not defined on the transaction object because blockchains with smart contracts may have transactions that partially apply (some operations are successful and some are not). Blockchains with atomic transactions (all operations succeed or all operations fail) will have the same status for each operation. On-chain operations (operations retrieved in the `/block` and `/block/transaction` endpoints) MUST have a populated status field (anything on-chain must have succeeded or failed). However, operations provided during transaction construction (often times called \"intent\" in the documentation) MUST NOT have a populated status field (operations yet to be included on-chain have not yet succeeded or failed).",
             "type": "string",
             "example": "Reverted"
           },
@@ -967,6 +1133,9 @@
           },
           "currency": {
             "$ref": "#/components/schemas/Currency"
+          },
+          "metadata": {
+            "type": "object"
           }
         }
       },
@@ -1001,12 +1170,11 @@
         }
       },
       "SyncStatus": {
-        "description": "SyncStatus is used to provide additional context about an implementation's sync status. It is often used to indicate that an implementation is healthy when it cannot be queried  until some sync phase occurs. If an implementation is immediately queryable, this model is often not populated.",
+        "description": "SyncStatus is used to provide additional context about an implementation's sync status. This object is often used by implementations to indicate healthiness when block data cannot be queried until some sync phase completes or cannot be determined by comparing the timestamp of the most recent block with the current time.",
         "type": "object",
-        "required": ["current_index"],
         "properties": {
           "current_index": {
-            "description": "CurrentIndex is the index of the last synced block in the current stage.",
+            "description": "CurrentIndex is the index of the last synced block in the current stage. This is a separate field from current_block_identifier in NetworkStatusResponse because blocks with indices up to and including the current_index may not yet be queryable by the caller. To reiterate, all indices up to and including current_block_identifier in NetworkStatusResponse must be queryable via the /block endpoint (excluding indices less than oldest_block_identifier).",
             "type": "integer",
             "format": "int64",
             "example": 100
@@ -1021,6 +1189,10 @@
             "description": "Stage is the phase of the sync process.",
             "type": "string",
             "example": "header sync"
+          },
+          "synced": {
+            "description": "sycned is a boolean that indicates if an implementation has synced up to the most recent block. If this field is not populated, the caller should rely on a traditional tip timestamp comparison to determine if an implementation is synced. This field is particularly useful for quiescent blockchains (blocks only produced when there are pending transactions). In these blockchains, the most recent block could have a timestamp far behind the current time but the node could be healthy and at tip.",
+            "type": "boolean"
           }
         }
       },
@@ -1067,7 +1239,15 @@
       "Allow": {
         "description": "Allow specifies supported Operation status, Operation types, and all possible error statuses. This Allow object is used by clients to validate the correctness of a Rosetta Server implementation. It is expected that these clients will error if they receive some response that contains any of the above information that is not specified here.",
         "type": "object",
-        "required": ["operation_statuses", "operation_types", "errors", "historical_balance_lookup"],
+        "required": [
+          "operation_statuses",
+          "operation_types",
+          "errors",
+          "historical_balance_lookup",
+          "call_methods",
+          "balance_exemptions",
+          "mempool_coins"
+        ],
         "properties": {
           "operation_statuses": {
             "description": "All Operation.Status this implementation supports. Any status that is returned during parsing that is not listed here will cause client validation to error.",
@@ -1094,6 +1274,31 @@
           "historical_balance_lookup": {
             "type": "boolean",
             "description": "Any Rosetta implementation that supports querying the balance of an account at any height in the past should set this to true."
+          },
+          "timestamp_start_index": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "description": "If populated, `timestamp_start_index` indicates the first block index where block timestamps are considered valid (i.e. all blocks less than `timestamp_start_index` could have invalid timestamps). This is useful when the genesis block (or blocks) of a network have timestamp 0. If not populated, block timestamps are assumed to be valid for all available blocks."
+          },
+          "call_methods": {
+            "type": "array",
+            "description": "All methods that are supported by the /call endpoint. Communicating which parameters should be provided to /call is the responsibility of the implementer (this is en lieu of defining an entire type system and requiring the implementer to define that in Allow).",
+            "items": {
+              "type": "string",
+              "example": "eth_call"
+            }
+          },
+          "balance_exemptions": {
+            "type": "array",
+            "description": "BalanceExemptions is an array of BalanceExemption indicating which account balances could change without a corresponding Operation. BalanceExemptions should be used sparingly as they may introduce significant complexity for integrators that attempt to reconcile all account balance changes. If your implementation relies on any BalanceExemptions, you MUST implement historical balance lookup (the ability to query an account balance at any BlockIdentifier).",
+            "items": {
+              "$ref": "#/components/schemas/BalanceExemption"
+            }
+          },
+          "mempool_coins": {
+            "type": "boolean",
+            "description": "Any Rosetta implementation that can update an AccountIdentifier's unspent coins based on the contents of the mempool should populate this field as true. If false, requests to `/account/coins` that set `include_mempool` as true will be automatically rejected."
           }
         }
       },
@@ -1242,6 +1447,92 @@
           }
         }
       },
+      "BalanceExemption": {
+        "description": "BalanceExemption indicates that the balance for an exempt account could change without a corresponding Operation. This typically occurs with staking rewards, vesting balances, and Currencies with a dynamic supply. Currently, it is possible to exempt an account from strict reconciliation by SubAccountIdentifier.Address or by Currency. This means that any account with SubAccountIdentifier.Address would be exempt or any balance of a particular Currency would be exempt, respectively. BalanceExemptions should be used sparingly as they may introduce significant complexity for integrators that attempt to reconcile all account balance changes. If your implementation relies on any BalanceExemptions, you MUST implement historical balance lookup (the ability to query an account balance at any BlockIdentifier).",
+        "type": "object",
+        "properties": {
+          "sub_account_address": {
+            "description": "SubAccountAddress is the SubAccountIdentifier.Address that the BalanceExemption applies to (regardless of the value of SubAccountIdentifier.Metadata).",
+            "type": "string",
+            "example": "staking"
+          },
+          "currency": {
+            "$ref": "#/components/schemas/Currency"
+          },
+          "exemption_type": {
+            "$ref": "#/components/schemas/ExemptionType"
+          }
+        }
+      },
+      "ExemptionType": {
+        "description": "ExemptionType is used to indicate if the live balance for an account subject to a BalanceExemption could increase above, decrease below, or equal the computed balance. * greater_or_equal: The live balance may increase above or equal the computed balance. This typically   occurs with staking rewards that accrue on each block. * less_or_equal: The live balance may decrease below or equal the computed balance. This typically   occurs as balance moves from locked to spendable on a vesting account. * dynamic: The live balance may increase above, decrease below, or equal the computed balance. This   typically occurs with tokens that have a dynamic supply.",
+        "type": "string",
+        "enum": ["greater_or_equal", "less_or_equal", "dynamic"]
+      },
+      "BlockEvent": {
+        "description": "BlockEvent represents the addition or removal of a BlockIdentifier from storage. Streaming BlockEvents allows lightweight clients to update their own state without needing to implement their own syncing logic.",
+        "type": "object",
+        "required": ["sequence", "block_identifier", "type"],
+        "properties": {
+          "sequence": {
+            "description": "sequence is the unique identifier of a BlockEvent within the context of a NetworkIdentifier.",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "example": 5
+          },
+          "block_identifier": {
+            "$ref": "#/components/schemas/BlockIdentifier"
+          },
+          "type": {
+            "$ref": "#/components/schemas/BlockEventType"
+          }
+        }
+      },
+      "BlockEventType": {
+        "description": "BlockEventType determines if a BlockEvent represents the addition or removal of a block.",
+        "type": "string",
+        "enum": ["block_added", "block_removed"]
+      },
+      "Operator": {
+        "description": "Operator is used by query-related endpoints to determine how to apply conditions. If this field is not populated, the default `and` value will be used.",
+        "type": "string",
+        "enum": ["or", "and"]
+      },
+      "BlockTransaction": {
+        "description": "BlockTransaction contains a populated Transaction and the BlockIdentifier that contains it.",
+        "type": "object",
+        "required": ["block_identifier", "transaction"],
+        "properties": {
+          "block_identifier": {
+            "$ref": "#/components/schemas/BlockIdentifier"
+          },
+          "transaction": {
+            "$ref": "#/components/schemas/Transaction"
+          }
+        }
+      },
+      "RelatedTransaction": {
+        "description": "The related_transaction allows implementations to link together multiple transactions. An unpopulated network identifier indicates that the related transaction is on the same network.",
+        "type": "object",
+        "required": ["transaction_identifier", "direction"],
+        "properties": {
+          "network_identifier": {
+            "$ref": "#/components/schemas/NetworkIdentifier"
+          },
+          "transaction_identifier": {
+            "$ref": "#/components/schemas/TransactionIdentifier"
+          },
+          "direction": {
+            "$ref": "#/components/schemas/Direction"
+          }
+        }
+      },
+      "Direction": {
+        "description": "Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may reference `backward` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if a transaction relation is from child to parent or the reverse.",
+        "type": "string",
+        "enum": ["forward", "backward"]
+      },
       "AccountBalanceRequest": {
         "description": "An AccountBalanceRequest is utilized to make a balance request on the /account/balance endpoint. If the block_identifier is populated, a historical balance query should be performed.",
         "type": "object",
@@ -1255,11 +1546,18 @@
           },
           "block_identifier": {
             "$ref": "#/components/schemas/PartialBlockIdentifier"
+          },
+          "currencies": {
+            "type": "array",
+            "description": "In some cases, the caller may not want to retrieve all available balances for an AccountIdentifier. If the currencies field is populated, only balances for the specified currencies will be returned. If not populated, all available balances will be returned.",
+            "items": {
+              "$ref": "#/components/schemas/Currency"
+            }
           }
         }
       },
       "AccountBalanceResponse": {
-        "description": "An AccountBalanceResponse is returned on the /account/balance endpoint. If an account has a balance for each AccountIdentifier describing it (ex: an ERC-20 token balance on a few smart contracts), an account balance request must be made with each AccountIdentifier.",
+        "description": "An AccountBalanceResponse is returned on the /account/balance endpoint. If an account has a balance for each AccountIdentifier describing it (ex: an ERC-20 token balance on a few smart contracts), an account balance request must be made with each AccountIdentifier. The `coins` field was removed and replaced by by `/account/coins` in `v1.4.7`.",
         "type": "object",
         "required": ["block_identifier", "balances"],
         "properties": {
@@ -1272,6 +1570,47 @@
             "items": {
               "$ref": "#/components/schemas/Amount"
             }
+          },
+          "metadata": {
+            "description": "Account-based blockchains that utilize a nonce or sequence number should include that number in the metadata. This number could be unique to the identifier or global across the account address.",
+            "type": "object",
+            "example": {
+              "sequence_number": 23
+            }
+          }
+        }
+      },
+      "AccountCoinsRequest": {
+        "description": "AccountCoinsRequest is utilized to make a request on the /account/coins endpoint.",
+        "type": "object",
+        "required": ["network_identifier", "account_identifier", "include_mempool"],
+        "properties": {
+          "network_identifier": {
+            "$ref": "#/components/schemas/NetworkIdentifier"
+          },
+          "account_identifier": {
+            "$ref": "#/components/schemas/AccountIdentifier"
+          },
+          "include_mempool": {
+            "type": "boolean",
+            "description": "Include state from the mempool when looking up an account's unspent coins. Note, using this functionality breaks any guarantee of idempotency."
+          },
+          "currencies": {
+            "type": "array",
+            "description": "In some cases, the caller may not want to retrieve coins for all currencies for an AccountIdentifier. If the currencies field is populated, only coins for the specified currencies will be returned. If not populated, all unspent coins will be returned.",
+            "items": {
+              "$ref": "#/components/schemas/Currency"
+            }
+          }
+        }
+      },
+      "AccountCoinsResponse": {
+        "description": "AccountCoinsResponse is returned on the /account/coins endpoint and includes all unspent Coins owned by an AccountIdentifier.",
+        "type": "object",
+        "required": ["block_identifier", "coins"],
+        "properties": {
+          "block_identifier": {
+            "$ref": "#/components/schemas/BlockIdentifier"
           },
           "coins": {
             "type": "array",
@@ -1303,7 +1642,7 @@
         }
       },
       "BlockResponse": {
-        "description": "A BlockResponse includes a fully-populated block or a partially-populated block with a list of other transactions to fetch (other_transactions). As a result of the consensus algorithm of some blockchains, blocks can be omitted (i.e. certain block indexes can be skipped). If a query for one of these omitted indexes is made, the response should not include a `Block` object. It is VERY important to note that blocks MUST still form a canonical, connected chain of blocks where each block has a unique index. In other words, the `PartialBlockIdentifier` of a block after an omitted block should reference the last non-omitted block.",
+        "description": "A BlockResponse includes a fully-populated block or a partially-populated block with a list of other transactions to fetch (other_transactions). As a result of the consensus algorithm of some blockchains, blocks can be omitted (i.e. certain block indices can be skipped). If a query for one of these omitted indices is made, the response should not include a `Block` object. It is VERY important to note that blocks MUST still form a canonical, connected chain of blocks where each block has a unique index. In other words, the `PartialBlockIdentifier` of a block after an omitted block should reference the last non-omitted block.",
         "type": "object",
         "required": ["block"],
         "properties": {
@@ -1465,9 +1804,9 @@
         }
       },
       "ConstructionMetadataRequest": {
-        "description": "A ConstructionMetadataRequest is utilized to get information required to construct a transaction. The Options object used to specify which metadata to return is left purposely unstructured to allow flexibility for implementers. Optionally, the request can also include an array of PublicKeys associated with the AccountIdentifiers returned in ConstructionPreprocessResponse.",
+        "description": "A ConstructionMetadataRequest is utilized to get information required to construct a transaction. The Options object used to specify which metadata to return is left purposely unstructured to allow flexibility for implementers. Options is not required in the case that there is network-wide metadata of interest. Optionally, the request can also include an array of PublicKeys associated with the AccountIdentifiers returned in ConstructionPreprocessResponse.",
         "type": "object",
-        "required": ["network_identifier", "options"],
+        "required": ["network_identifier"],
         "properties": {
           "network_identifier": {
             "$ref": "#/components/schemas/NetworkIdentifier"
@@ -1611,7 +1950,7 @@
       "ConstructionPayloadsRequest": {
         "description": "ConstructionPayloadsRequest is the request to `/construction/payloads`. It contains the network, a slice of operations, and arbitrary metadata that was returned by the call to `/construction/metadata`. Optionally, the request can also include an array of PublicKeys associated with the AccountIdentifiers returned in ConstructionPreprocessResponse.",
         "type": "object",
-        "required": ["network_identifier", "operations", "metadata"],
+        "required": ["network_identifier", "operations"],
         "properties": {
           "network_identifier": {
             "$ref": "#/components/schemas/NetworkIdentifier"
@@ -1623,11 +1962,7 @@
             }
           },
           "metadata": {
-            "type": "object",
-            "required": ["ttl"],
-            "properties": {
-              "ttl": { "type": "string" }
-            }
+            "type": "object"
           },
           "public_keys": {
             "type": "array",
@@ -1768,6 +2103,185 @@
           }
         }
       },
+      "CallRequest": {
+        "description": "CallRequest is the input to the `/call` endpoint.",
+        "type": "object",
+        "required": ["network_identifier", "method", "parameters"],
+        "properties": {
+          "network_identifier": {
+            "$ref": "#/components/schemas/NetworkIdentifier"
+          },
+          "method": {
+            "type": "string",
+            "description": "Method is some network-specific procedure call. This method could map to a network-specific RPC endpoint, a method in an SDK generated from a smart contract, or some hybrid of the two. The implementation must define all available methods in the Allow object. However, it is up to the caller to determine which parameters to provide when invoking `/call`.",
+            "example": "eth_call"
+          },
+          "parameters": {
+            "type": "object",
+            "description": "Parameters is some network-specific argument for a method. It is up to the caller to determine which parameters to provide when invoking `/call`.",
+            "example": {
+              "block_number": 23,
+              "address": "0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5"
+            }
+          }
+        }
+      },
+      "CallResponse": {
+        "description": "CallResponse contains the result of a `/call` invocation.",
+        "type": "object",
+        "required": ["result", "idempotent"],
+        "properties": {
+          "result": {
+            "type": "object",
+            "description": "Result contains the result of the `/call` invocation. This result will not be inspected or interpreted by Rosetta tooling and is left to the caller to decode.",
+            "example": {
+              "count": 1000
+            }
+          },
+          "idempotent": {
+            "type": "boolean",
+            "description": "Idempotent indicates that if `/call` is invoked with the same CallRequest again, at any point in time, it will return the same CallResponse. Integrators may cache the CallResponse if this is set to true to avoid making unnecessary calls to the Rosetta implementation. For this reason, implementers should be very conservative about returning true here or they could cause issues for the caller."
+          }
+        }
+      },
+      "EventsBlocksRequest": {
+        "description": "EventsBlocksRequest is utilized to fetch a sequence of BlockEvents indicating which blocks were added and removed from storage to reach the current state.",
+        "type": "object",
+        "required": ["network_identifier"],
+        "properties": {
+          "network_identifier": {
+            "$ref": "#/components/schemas/NetworkIdentifier"
+          },
+          "offset": {
+            "description": "offset is the offset into the event stream to sync events from. If this field is not populated, we return the limit events backwards from tip. If this is set to 0, we start from the beginning.",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "example": 5
+          },
+          "limit": {
+            "description": "limit is the maximum number of events to fetch in one call. The implementation may return <= limit events.",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "example": 5
+          }
+        }
+      },
+      "EventsBlocksResponse": {
+        "description": "EventsBlocksResponse contains an ordered collection of BlockEvents and the max retrievable sequence.",
+        "type": "object",
+        "required": ["max_sequence", "events"],
+        "properties": {
+          "max_sequence": {
+            "description": "max_sequence is the maximum available sequence number to fetch.",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "example": 5
+          },
+          "events": {
+            "type": "array",
+            "description": "events is an array of BlockEvents indicating the order to add and remove blocks to maintain a canonical view of blockchain state. Lightweight clients can use this event stream to update state without implementing their own block syncing logic.",
+            "items": {
+              "$ref": "#/components/schemas/BlockEvent"
+            }
+          }
+        }
+      },
+      "SearchTransactionsRequest": {
+        "description": "SearchTransactionsRequest is used to search for transactions matching a set of provided conditions in canonical blocks.",
+        "type": "object",
+        "required": ["network_identifier"],
+        "properties": {
+          "network_identifier": {
+            "$ref": "#/components/schemas/NetworkIdentifier"
+          },
+          "operator": {
+            "$ref": "#/components/schemas/Operator"
+          },
+          "max_block": {
+            "description": "max_block is the largest block index to consider when searching for transactions. If this field is not populated, the current block is considered the max_block. If you do not specify a max_block, it is possible a newly synced block will interfere with paginated transaction queries (as the offset could become invalid with newly added rows).",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "example": 5
+          },
+          "offset": {
+            "description": "offset is the offset into the query result to start returning transactions. If any search conditions are changed, the query offset will change and you must restart your search iteration.",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "example": 5
+          },
+          "limit": {
+            "description": "limit is the maximum number of transactions to return in one call. The implementation may return <= limit transactions.",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "example": 5
+          },
+          "transaction_identifier": {
+            "$ref": "#/components/schemas/TransactionIdentifier"
+          },
+          "account_identifier": {
+            "$ref": "#/components/schemas/AccountIdentifier"
+          },
+          "coin_identifier": {
+            "$ref": "#/components/schemas/CoinIdentifier"
+          },
+          "currency": {
+            "$ref": "#/components/schemas/Currency"
+          },
+          "status": {
+            "type": "string",
+            "description": "status is the network-specific operation type.",
+            "example": "reverted"
+          },
+          "type": {
+            "type": "string",
+            "description": "type is the network-specific operation type.",
+            "example": "transfer"
+          },
+          "address": {
+            "type": "string",
+            "description": "address is AccountIdentifier.Address. This is used to get all transactions related to an AccountIdentifier.Address, regardless of SubAccountIdentifier.",
+            "example": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "success is a synthetic condition populated by parsing network-specific operation statuses (using the mapping provided in `/network/options`)."
+          }
+        }
+      },
+      "SearchTransactionsResponse": {
+        "description": "SearchTransactionsResponse contains an ordered collection of BlockTransactions that match the query in SearchTransactionsRequest. These BlockTransactions are sorted from most recent block to oldest block.",
+        "type": "object",
+        "required": ["transactions", "total_count"],
+        "properties": {
+          "transactions": {
+            "type": "array",
+            "description": "transactions is an array of BlockTransactions sorted by most recent BlockIdentifier (meaning that transactions in recent blocks appear first). If there are many transactions for a particular search, transactions may not contain all matching transactions. It is up to the caller to paginate these transactions using the max_block field.",
+            "items": {
+              "$ref": "#/components/schemas/BlockTransaction"
+            }
+          },
+          "total_count": {
+            "description": "total_count is the number of results for a given search. Callers typically use this value to concurrently fetch results by offset or to display a virtual page number associated with results.",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "example": 5
+          },
+          "next_offset": {
+            "description": "next_offset is the next offset to use when paginating through transaction results. If this field is not populated, there are no more transactions to query.",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "example": 5
+          }
+        }
+      },
       "Error": {
         "description": "Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields.",
         "type": "object",
@@ -1784,6 +2298,11 @@
             "description": "Message is a network-specific error message. The message MUST NOT change for a given code. In particular, this means that any contextual information should be included in the details field.",
             "type": "string",
             "example": "Invalid account format"
+          },
+          "description": {
+            "description": "Description allows the implementer to optionally provide additional information about an error. In many cases, the content of this field will be a copy-and-paste from existing developer documentation. Description can ONLY be populated with generic information about a particular type of error. It MUST NOT be populated with information about a particular instantiation of an error (use `details` for this). Whereas the content of Error.Message should stay stable across releases, the content of Error.Description will likely change across releases (as implementers improve error documentation). For this reason, the content in this field is not part of any type assertion (unlike Error.Message).",
+            "type": "string",
+            "example": "This error is returned when the requested AccountIdentifier is improperly formatted."
           },
           "retriable": {
             "description": "An error is retriable if the same request may succeed if submitted again.",

--- a/cardano-rosetta-server/src/server/services/block-service.ts
+++ b/cardano-rosetta-server/src/server/services/block-service.ts
@@ -90,7 +90,11 @@ export interface BlockService {
    * @param logger
    * @param address
    */
-  findCoinsDataByAddress(logger: Logger, address: string): Promise<BlockUtxos>;
+  findCoinsDataByAddress(
+    logger: Logger,
+    address: string,
+    currencies?: Components.Schemas.Currency[]
+  ): Promise<BlockUtxos>;
 }
 
 const configure = (repository: BlockchainRepository, cardanoService: CardanoService): BlockService => ({
@@ -187,14 +191,17 @@ const configure = (repository: BlockchainRepository, cardanoService: CardanoServ
       maBalances
     };
   },
-  async findCoinsDataByAddress(logger, address) {
+  async findCoinsDataByAddress(logger, address, currencies) {
     const block = await this.findBlock(logger);
     if (block === null) {
       logger.error('[findCoinsDataByAddress] Block not found');
       throw ErrorFactory.blockNotFoundError();
     }
-    logger.info(`[findCoinsDataByAddress] Looking for utxos for address ${address}`);
-    const utxoDetails = await repository.findUtxoByAddressAndBlock(logger, address, block.hash);
+    logger.info(
+      `[findCoinsDataByAddress] Looking for utxos for address ${address} and ${currencies?.length ||
+        '0'} specified currencies`
+    );
+    const utxoDetails = await repository.findUtxoByAddressAndBlock(logger, address, block.hash, currencies);
     logger.debug(utxoDetails, `[findCoinsByAddress] Found ${utxoDetails.length} coin details for address ${address}`);
     return {
       block,

--- a/cardano-rosetta-server/src/server/services/block-service.ts
+++ b/cardano-rosetta-server/src/server/services/block-service.ts
@@ -93,7 +93,7 @@ export interface BlockService {
   findCoinsDataByAddress(
     logger: Logger,
     address: string,
-    currencies?: Components.Schemas.Currency[]
+    currencies: Components.Schemas.Currency[]
   ): Promise<BlockUtxos>;
 }
 
@@ -198,8 +198,7 @@ const configure = (repository: BlockchainRepository, cardanoService: CardanoServ
       throw ErrorFactory.blockNotFoundError();
     }
     logger.info(
-      `[findCoinsDataByAddress] Looking for utxos for address ${address} and ${currencies?.length ||
-        '0'} specified currencies`
+      `[findCoinsDataByAddress] Looking for utxos for address ${address} and ${currencies.length} specified currencies`
     );
     const utxoDetails = await repository.findUtxoByAddressAndBlock(logger, address, block.hash, currencies);
     logger.debug(utxoDetails, `[findCoinsByAddress] Found ${utxoDetails.length} coin details for address ${address}`);

--- a/cardano-rosetta-server/src/server/services/network-service.ts
+++ b/cardano-rosetta-server/src/server/services/network-service.ts
@@ -2,6 +2,9 @@ import { Logger } from 'fastify';
 import { Block, GenesisBlock, Network } from '../models';
 import { MAIN_TESTNET_NETWORK_MAGIC } from '../utils/constants';
 import { BlockService } from './block-service';
+import fs from 'fs';
+import path from 'path';
+const exemptionsFile = fs.readFileSync(path.resolve(process.env.EXEMPTION_TYPES_PATH)).toString();
 
 export interface NetworkStatus {
   latestBlock: Block;
@@ -11,6 +14,7 @@ export interface NetworkStatus {
 
 export interface NetworkService {
   getSupportedNetwork(): Network;
+  getExemptionTypes(): Components.Schemas.BalanceExemption[];
   getNetworkStatus(logger: Logger): Promise<NetworkStatus>;
 }
 
@@ -57,6 +61,9 @@ const configure = (
       genesisBlock,
       peers: getPeersFromConfig(logger, topologyFile)
     };
+  },
+  getExemptionTypes() {
+    return JSON.parse(exemptionsFile);
   }
 });
 

--- a/cardano-rosetta-server/src/server/services/network-service.ts
+++ b/cardano-rosetta-server/src/server/services/network-service.ts
@@ -4,7 +4,9 @@ import { MAIN_TESTNET_NETWORK_MAGIC } from '../utils/constants';
 import { BlockService } from './block-service';
 import fs from 'fs';
 import path from 'path';
-const exemptionsFile = fs.readFileSync(path.resolve(process.env.EXEMPTION_TYPES_PATH)).toString();
+const exemptionsFile = process.env.EXEMPTION_TYPES_PATH
+  ? fs.readFileSync(path.resolve(process.env.EXEMPTION_TYPES_PATH)).toString()
+  : process.env.EXEMPTION_TYPES_PATH;
 
 export interface NetworkStatus {
   latestBlock: Block;
@@ -63,7 +65,7 @@ const configure = (
     };
   },
   getExemptionTypes() {
-    return JSON.parse(exemptionsFile);
+    return exemptionsFile ? JSON.parse(exemptionsFile) : [];
   }
 });
 

--- a/cardano-rosetta-server/src/server/utils/data-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/data-mapper.ts
@@ -352,7 +352,7 @@ export const mapToAccountBalanceResponse = (
         hash: blockBalanceData.block.hash
       },
       balances: totalBalance.length === 0 ? [mapAmount('0')] : totalBalance,
-      coins: [...adaCoins.values()]
+      // coins: [...adaCoins.values()]
     };
   }
   return {

--- a/cardano-rosetta-server/src/server/utils/data-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/data-mapper.ts
@@ -471,3 +471,7 @@ export const constructPayloadsForTransactionBody = (
     hex_bytes: transactionBodyHash,
     signature_type: SIGNATURE_TYPE
   }));
+
+// if ADA is requested then all coins will be returned
+export const filterRequestedCurrencies = (currencies?: Components.Schemas.Currency[]): Components.Schemas.Currency[] =>
+  currencies && !currencies.map(currency => currency.symbol).some(s => s === ADA) ? currencies : [];

--- a/cardano-rosetta-server/src/server/utils/data-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/data-mapper.ts
@@ -1,7 +1,16 @@
 /* eslint-disable camelcase */
 
 import cbor from 'cbor';
-import { BalanceAtBlock, Block, BlockUtxos, Network, PopulatedTransaction, TokenBundle, Utxo } from '../models';
+import {
+  BalanceAtBlock,
+  Block,
+  BlockUtxos,
+  BlockUtxosMultiAssets,
+  Network,
+  PopulatedTransaction,
+  TokenBundle,
+  Utxo
+} from '../models';
 import { NetworkStatus } from '../services/network-service';
 import {
   ADA,
@@ -290,42 +299,34 @@ const updateMetadataCoin = (
   return updatedCoin;
 };
 
-const mapToAddressBalanceAndCoins = (
-  blockBalanceData: BlockUtxos
-): { adaBalance: Components.Schemas.Amount; adaCoins: Map<string, Components.Schemas.Coin> } => {
-  const mappedUtxos = blockBalanceData.utxos.reduce(
-    ({ adaBalance, adaCoins }, current, index) => {
-      const previousValue = blockBalanceData.utxos[index - 1];
-      // This function accumulates ADA value. As there might be several, one for each multi-asset, we need to
-      // avoid counting them twice
-      const coinId = `${current.transactionHash}:${current.index}`;
-      if (!previousValue || !areEqualUtxos(previousValue, current)) {
-        adaBalance += BigInt(current.value);
-        adaCoins.set(coinId, {
-          coin_identifier: {
-            identifier: coinId
-          },
-          amount: mapAmount(current.value)
-        });
-      }
-      if (current.policy && current.name !== undefined && current.quantity) {
-        // MultiAsset
-        const relatedCoin = adaCoins.get(coinId);
-        if (relatedCoin) {
-          const updatedCoin = updateMetadataCoin(relatedCoin, current.policy, current.quantity, current.name);
-          adaCoins.set(coinId, updatedCoin);
-        }
-      }
-      return { adaBalance, adaCoins };
-    },
-    {
-      adaBalance: BigInt(0),
-      adaCoins: new Map<string, Components.Schemas.Coin>()
+export const mapToAccountCoinsResponse = (blockCoinsData: BlockUtxos): Components.Schemas.AccountCoinsResponse => {
+  const mappedUtxos = blockCoinsData.utxos.reduce((adaCoins, current, index) => {
+    const previousValue = blockCoinsData.utxos[index - 1];
+    const coinId = `${current.transactionHash}:${current.index}`;
+    if (!previousValue || !areEqualUtxos(previousValue, current)) {
+      adaCoins.set(coinId, {
+        coin_identifier: {
+          identifier: coinId
+        },
+        amount: mapAmount(current.value)
+      });
     }
-  );
+    if (current.policy && current.name !== undefined && current.quantity) {
+      // MultiAsset
+      const relatedCoin = adaCoins.get(coinId);
+      if (relatedCoin) {
+        const updatedCoin = updateMetadataCoin(relatedCoin, current.policy, current.quantity, current.name);
+        adaCoins.set(coinId, updatedCoin);
+      }
+    }
+    return adaCoins;
+  }, new Map<string, Components.Schemas.Coin>());
   return {
-    adaBalance: mapAmount(mappedUtxos.adaBalance.toString()),
-    adaCoins: mappedUtxos.adaCoins
+    block_identifier: {
+      index: blockCoinsData.block.number,
+      hash: blockCoinsData.block.hash
+    },
+    coins: [...mappedUtxos.values()]
   };
 };
 
@@ -335,7 +336,7 @@ const mapToAddressBalanceAndCoins = (
  * @param accountAddress
  */
 export const mapToAccountBalanceResponse = (
-  blockBalanceData: BlockUtxos | BalanceAtBlock
+  blockBalanceData: BlockUtxosMultiAssets | BalanceAtBlock
 ): Components.Schemas.AccountBalanceResponse => {
   if (isBlockUtxos(blockBalanceData)) {
     const maBalances =
@@ -344,15 +345,22 @@ export const mapToAccountBalanceResponse = (
             mapAmount(maBalance.value, maBalance.name, MULTI_ASSET_DECIMALS, { policyId: maBalance.policy })
           )
         : [];
-    const { adaBalance, adaCoins } = mapToAddressBalanceAndCoins(blockBalanceData);
-    const totalBalance = [adaBalance, ...maBalances];
+    const adaBalance = blockBalanceData.utxos.reduce((totalAmount, current, index) => {
+      const previousValue = blockBalanceData.utxos[index - 1];
+      // This function accumulates ADA value. As there might be several, one for each multi-asset, we need to
+      // avoid counting them twice
+      if (!previousValue || !areEqualUtxos(previousValue, current)) {
+        totalAmount += BigInt(current.value);
+      }
+      return totalAmount;
+    }, BigInt(0));
+    const totalBalance = [mapAmount(adaBalance.toString()), ...maBalances];
     return {
       block_identifier: {
         index: blockBalanceData.block.number,
         hash: blockBalanceData.block.hash
       },
       balances: totalBalance.length === 0 ? [mapAmount('0')] : totalBalance
-      // coins: [...adaCoins.values()]
     };
   }
   return {

--- a/cardano-rosetta-server/src/server/utils/data-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/data-mapper.ts
@@ -351,7 +351,7 @@ export const mapToAccountBalanceResponse = (
         index: blockBalanceData.block.number,
         hash: blockBalanceData.block.hash
       },
-      balances: totalBalance.length === 0 ? [mapAmount('0')] : totalBalance,
+      balances: totalBalance.length === 0 ? [mapAmount('0')] : totalBalance
       // coins: [...adaCoins.values()]
     };
   }
@@ -456,4 +456,10 @@ export const constructPayloadsForTransactionBody = (
   transactionBodyHash: string,
   addresses: string[]
 ): Components.Schemas.SigningPayload[] =>
-  addresses.map(address => ({ address, hex_bytes: transactionBodyHash, signature_type: SIGNATURE_TYPE }));
+  addresses.map(address => ({
+    account_identifier: {
+      address
+    },
+    hex_bytes: transactionBodyHash,
+    signature_type: SIGNATURE_TYPE
+  }));

--- a/cardano-rosetta-server/src/server/utils/errors.ts
+++ b/cardano-rosetta-server/src/server/utils/errors.ts
@@ -67,9 +67,11 @@ export const Errors = {
     code: 4019
   },
   POOL_KEY_MISSING: { message: 'Pool key hash is required for stake delegation', code: 4020 },
-  INVALID_POOL_KEY_HASH: { message: 'Provided pool key hash has invalid format', code: 4021 },
-  TOKEN_BUNDLE_ASSETS_MISSING: { message: 'Assets are required for output operation token bundle', code: 4022 },
-  TOKEN_ASSET_VALUE_MISSING: { message: 'Asset value is required for token asset', code: 4023 },
+  TOKEN_BUNDLE_ASSETS_MISSING: { message: 'Assets are required for output operation token bundle', code: 4021 },
+  TOKEN_ASSET_VALUE_MISSING: { message: 'Asset value is required for token asset', code: 4022 },
+  INVALID_POLICY_ID: { message: 'Invalid policy id', code: 4023 },
+  INVALID_TOKEN_NAME: { message: 'Invalid token name', code: 4024 },
+  INVALID_POOL_KEY_HASH: { message: 'Provided pool key hash has invalid format', code: 4025 },
   UNSPECIFIED_ERROR: { message: 'An error occurred', code: 5000 },
   NOT_IMPLEMENTED: { message: 'Not implemented', code: 5001 },
   ADDRESS_GENERATION_ERROR: { message: 'Address generation error', code: 5002 },
@@ -127,6 +129,10 @@ const transactionOutputDeserializationError: CreateErrorFunction = (details?: st
 const invalidAddressError: CreateErrorFunction = address => buildApiError(Errors.INVALID_ADDRESS, true, address);
 const invalidAddressTypeError: CreateErrorFunction = type => buildApiError(Errors.INVALID_ADDRESS_TYPE, true, type);
 const invalidOperationTypeError: CreateErrorFunction = type => buildApiError(Errors.INVALID_OPERATION_TYPE, true, type);
+const invalidPolicyIdError: CreateErrorFunction = (details?: string) =>
+  buildApiError(Errors.INVALID_POLICY_ID, false, details);
+const invalidTokenNameError: CreateErrorFunction = (details?: string) =>
+  buildApiError(Errors.INVALID_TOKEN_NAME, false, details);
 const tokenBundleAssetsMissingError: CreateErrorFunction = type =>
   buildApiError(Errors.TOKEN_BUNDLE_ASSETS_MISSING, false, type);
 const tokenAssetValueMissingError: CreateErrorFunction = type =>
@@ -158,6 +164,8 @@ export const ErrorFactory = {
   sendTransactionError,
   transactionInputDeserializationError,
   transactionOutputDeserializationError,
+  invalidPolicyIdError,
+  invalidTokenNameError,
   invalidAddressError,
   invalidAddressTypeError,
   invalidOperationTypeError,

--- a/cardano-rosetta-server/src/server/utils/validations.ts
+++ b/cardano-rosetta-server/src/server/utils/validations.ts
@@ -1,4 +1,5 @@
-import { PUBLIC_KEY_BYTES_LENGTH, AddressType, CurveType, ASSET_NAME_LENGTH, POLICY_ID_LENGTH } from './constants';
+import { PUBLIC_KEY_BYTES_LENGTH, ADA, AddressType, CurveType, ASSET_NAME_LENGTH, POLICY_ID_LENGTH } from './constants';
+import { ErrorFactory } from './errors';
 import { isEmptyHexString } from './formatters';
 
 const tokenNameValidation = new RegExp(`^[0-9a-fA-F]{0,${ASSET_NAME_LENGTH}}$`);
@@ -16,3 +17,11 @@ export const isAddressTypeValid = (type: string): boolean =>
 export const isTokenNameValid = (name: string): boolean => tokenNameValidation.test(name) || isEmptyHexString(name);
 
 export const isPolicyIdValid = (policyId: string): boolean => policyIdValidation.test(policyId);
+
+export const validateCurrencies = (currencies: Components.Schemas.Currency[]): void => {
+  currencies.forEach(({ symbol, metadata }) => {
+    if (!isTokenNameValid(symbol)) throw ErrorFactory.invalidTokenNameError(`Given name is ${symbol}`);
+    if (symbol !== ADA && !isPolicyIdValid(metadata.policyId))
+      throw ErrorFactory.invalidPolicyIdError(`Given policy id is ${metadata.policyId}`);
+  });
+};

--- a/cardano-rosetta-server/src/types/app.d.ts
+++ b/cardano-rosetta-server/src/types/app.d.ts
@@ -10,5 +10,6 @@ declare namespace NodeJS {
     DEFAULT_RELATIVE_TTL: number;
     CARDANO_NODE_PATH: string;
     TOPOLOGY_FILE_PATH: string;
+    EXEMPTION_TYPES_PATH: string;
   }
 }

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -39,7 +39,7 @@ declare namespace Components {
       /**
        * Include state from the mempool when looking up an account's unspent coins. Note, using this functionality breaks any guarantee of idempotency.
        */
-      include_mempool: boolean;
+      include_mempool?: boolean;
       /**
        * In some cases, the caller may not want to retrieve coins for all currencies for an AccountIdentifier. If the currencies field is populated, only coins for the specified currencies will be returned. If not populated, all unspent coins will be returned.
        */

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -7,9 +7,13 @@ declare namespace Components {
       network_identifier: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
       account_identifier: /* The account_identifier uniquely identifies an account within a network. All fields in the account_identifier are utilized to determine this uniqueness (including the metadata field, if populated). */ AccountIdentifier;
       block_identifier?: /* When fetching data by BlockIdentifier, it may be possible to only specify the index or hash. If neither property is specified, it is assumed that the client is making a request at the current block. */ PartialBlockIdentifier;
+      /**
+       * In some cases, the caller may not want to retrieve all available balances for an AccountIdentifier. If the currencies field is populated, only balances for the specified currencies will be returned. If not populated, all available balances will be returned.
+       */
+      currencies?: /* Currency is composed of a canonical Symbol and Decimals. This Decimals value is used to convert an Amount.Value from atomic units (Satoshis) to standard units (Bitcoins). */ Currency[];
     }
     /**
-     * An AccountBalanceResponse is returned on the /account/balance endpoint. If an account has a balance for each AccountIdentifier describing it (ex: an ERC-20 token balance on a few smart contracts), an account balance request must be made with each AccountIdentifier.
+     * An AccountBalanceResponse is returned on the /account/balance endpoint. If an account has a balance for each AccountIdentifier describing it (ex: an ERC-20 token balance on a few smart contracts), an account balance request must be made with each AccountIdentifier. The `coins` field was removed and replaced by by `/account/coins` in `v1.4.7`.
      */
     export interface AccountBalanceResponse {
       block_identifier: /* The block_identifier uniquely identifies a block in a particular network. */ BlockIdentifier;
@@ -18,9 +22,38 @@ declare namespace Components {
        */
       balances: /* Amount is some Value of a Currency. It is considered invalid to specify a Value without a Currency. */ Amount[];
       /**
+       * Account-based blockchains that utilize a nonce or sequence number should include that number in the metadata. This number could be unique to the identifier or global across the account address.
+       * example:
+       * {
+       *   "sequence_number": 23
+       * }
+       */
+      metadata?: {};
+    }
+    /**
+     * AccountCoinsRequest is utilized to make a request on the /account/coins endpoint.
+     */
+    export interface AccountCoinsRequest {
+      network_identifier: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
+      account_identifier: /* The account_identifier uniquely identifies an account within a network. All fields in the account_identifier are utilized to determine this uniqueness (including the metadata field, if populated). */ AccountIdentifier;
+      /**
+       * Include state from the mempool when looking up an account's unspent coins. Note, using this functionality breaks any guarantee of idempotency.
+       */
+      include_mempool: boolean;
+      /**
+       * In some cases, the caller may not want to retrieve coins for all currencies for an AccountIdentifier. If the currencies field is populated, only coins for the specified currencies will be returned. If not populated, all unspent coins will be returned.
+       */
+      currencies?: /* Currency is composed of a canonical Symbol and Decimals. This Decimals value is used to convert an Amount.Value from atomic units (Satoshis) to standard units (Bitcoins). */ Currency[];
+    }
+    /**
+     * AccountCoinsResponse is returned on the /account/coins endpoint and includes all unspent Coins owned by an AccountIdentifier.
+     */
+    export interface AccountCoinsResponse {
+      block_identifier: /* The block_identifier uniquely identifies a block in a particular network. */ BlockIdentifier;
+      /**
        * If a blockchain is UTXO-based, all unspent Coins owned by an account_identifier should be returned alongside the balance. It is highly recommended to populate this field so that users of the Rosetta API implementation don't need to maintain their own indexer to track their UTXOs.
        */
-      coins?: /* Coin contains its unique identifier and the amount it represents. */ Coin[];
+      coins: /* Coin contains its unique identifier and the amount it represents. */ Coin[];
       /**
        * Account-based blockchains that utilize a nonce or sequence number should include that number in the metadata. This number could be unique to the identifier or global across the account address.
        * example:
@@ -78,6 +111,22 @@ declare namespace Components {
        * Any Rosetta implementation that supports querying the balance of an account at any height in the past should set this to true.
        */
       historical_balance_lookup: boolean;
+      /**
+       * If populated, `timestamp_start_index` indicates the first block index where block timestamps are considered valid (i.e. all blocks less than `timestamp_start_index` could have invalid timestamps). This is useful when the genesis block (or blocks) of a network have timestamp 0. If not populated, block timestamps are assumed to be valid for all available blocks.
+       */
+      timestamp_start_index?: number; // int64
+      /**
+       * All methods that are supported by the /call endpoint. Communicating which parameters should be provided to /call is the responsibility of the implementer (this is en lieu of defining an entire type system and requiring the implementer to define that in Allow).
+       */
+      call_methods: string[];
+      /**
+       * BalanceExemptions is an array of BalanceExemption indicating which account balances could change without a corresponding Operation. BalanceExemptions should be used sparingly as they may introduce significant complexity for integrators that attempt to reconcile all account balance changes. If your implementation relies on any BalanceExemptions, you MUST implement historical balance lookup (the ability to query an account balance at any BlockIdentifier).
+       */
+      balance_exemptions: /* BalanceExemption indicates that the balance for an exempt account could change without a corresponding Operation. This typically occurs with staking rewards, vesting balances, and Currencies with a dynamic supply. Currently, it is possible to exempt an account from strict reconciliation by SubAccountIdentifier.Address or by Currency. This means that any account with SubAccountIdentifier.Address would be exempt or any balance of a particular Currency would be exempt, respectively. BalanceExemptions should be used sparingly as they may introduce significant complexity for integrators that attempt to reconcile all account balance changes. If your implementation relies on any BalanceExemptions, you MUST implement historical balance lookup (the ability to query an account balance at any BlockIdentifier). */ BalanceExemption[];
+      /**
+       * Any Rosetta implementation that can update an AccountIdentifier's unspent coins based on the contents of the mempool should populate this field as true. If false, requests to `/account/coins` that set `include_mempool` as true will be automatically rejected.
+       */
+      mempool_coins: boolean;
     }
     /**
      * Amount is some Value of a Currency. It is considered invalid to specify a Value without a Currency.
@@ -90,6 +139,20 @@ declare namespace Components {
        */
       value: string;
       currency: /* Currency is composed of a canonical Symbol and Decimals. This Decimals value is used to convert an Amount.Value from atomic units (Satoshis) to standard units (Bitcoins). */ Currency;
+      metadata?: {};
+    }
+    /**
+     * BalanceExemption indicates that the balance for an exempt account could change without a corresponding Operation. This typically occurs with staking rewards, vesting balances, and Currencies with a dynamic supply. Currently, it is possible to exempt an account from strict reconciliation by SubAccountIdentifier.Address or by Currency. This means that any account with SubAccountIdentifier.Address would be exempt or any balance of a particular Currency would be exempt, respectively. BalanceExemptions should be used sparingly as they may introduce significant complexity for integrators that attempt to reconcile all account balance changes. If your implementation relies on any BalanceExemptions, you MUST implement historical balance lookup (the ability to query an account balance at any BlockIdentifier).
+     */
+    export interface BalanceExemption {
+      /**
+       * SubAccountAddress is the SubAccountIdentifier.Address that the BalanceExemption applies to (regardless of the value of SubAccountIdentifier.Metadata).
+       * example:
+       * staking
+       */
+      sub_account_address?: string;
+      currency?: /* Currency is composed of a canonical Symbol and Decimals. This Decimals value is used to convert an Amount.Value from atomic units (Satoshis) to standard units (Bitcoins). */ Currency;
+      exemption_type?: /* ExemptionType is used to indicate if the live balance for an account subject to a BalanceExemption could increase above, decrease below, or equal the computed balance. * greater_or_equal: The live balance may increase above or equal the computed balance. This typically   occurs with staking rewards that accrue on each block. * less_or_equal: The live balance may decrease below or equal the computed balance. This typically   occurs as balance moves from locked to spendable on a vesting account. * dynamic: The live balance may increase above, decrease below, or equal the computed balance. This   typically occurs with tokens that have a dynamic supply. */ ExemptionType;
     }
     /**
      * Blocks contain an array of Transactions that occurred at a particular BlockIdentifier. A hard requirement for blocks returned by Rosetta implementations is that they MUST be _inalterable_: once a client has requested and received a block identified by a specific BlockIndentifier, all future calls for that same BlockIdentifier must return the same block contents.
@@ -120,6 +183,23 @@ declare namespace Components {
       };
     }
     /**
+     * BlockEvent represents the addition or removal of a BlockIdentifier from storage. Streaming BlockEvents allows lightweight clients to update their own state without needing to implement their own syncing logic.
+     */
+    export interface BlockEvent {
+      /**
+       * sequence is the unique identifier of a BlockEvent within the context of a NetworkIdentifier.
+       * example:
+       * 5
+       */
+      sequence: number; // int64
+      block_identifier: /* The block_identifier uniquely identifies a block in a particular network. */ BlockIdentifier;
+      type: /* BlockEventType determines if a BlockEvent represents the addition or removal of a block. */ BlockEventType;
+    }
+    /**
+     * BlockEventType determines if a BlockEvent represents the addition or removal of a block.
+     */
+    export type BlockEventType = 'block_added' | 'block_removed';
+    /**
      * The block_identifier uniquely identifies a block in a particular network.
      */
     export interface BlockIdentifier {
@@ -143,7 +223,7 @@ declare namespace Components {
       block_identifier: /* When fetching data by BlockIdentifier, it may be possible to only specify the index or hash. If neither property is specified, it is assumed that the client is making a request at the current block. */ PartialBlockIdentifier;
     }
     /**
-     * A BlockResponse includes a fully-populated block or a partially-populated block with a list of other transactions to fetch (other_transactions). As a result of the consensus algorithm of some blockchains, blocks can be omitted (i.e. certain block indexes can be skipped). If a query for one of these omitted indexes is made, the response should not include a `Block` object. It is VERY important to note that blocks MUST still form a canonical, connected chain of blocks where each block has a unique index. In other words, the `PartialBlockIdentifier` of a block after an omitted block should reference the last non-omitted block.
+     * A BlockResponse includes a fully-populated block or a partially-populated block with a list of other transactions to fetch (other_transactions). As a result of the consensus algorithm of some blockchains, blocks can be omitted (i.e. certain block indices can be skipped). If a query for one of these omitted indices is made, the response should not include a `Block` object. It is VERY important to note that blocks MUST still form a canonical, connected chain of blocks where each block has a unique index. In other words, the `PartialBlockIdentifier` of a block after an omitted block should reference the last non-omitted block.
      */
     export interface BlockResponse {
       block: /* Blocks contain an array of Transactions that occurred at a particular BlockIdentifier. A hard requirement for blocks returned by Rosetta implementations is that they MUST be _inalterable_: once a client has requested and received a block identified by a specific BlockIndentifier, all future calls for that same BlockIdentifier must return the same block contents. */ Block;
@@ -151,6 +231,13 @@ declare namespace Components {
        * Some blockchains may require additional transactions to be fetched that weren't returned in the block response (ex: block only returns transaction hashes). For blockchains with a lot of transactions in each block, this can be very useful as consumers can concurrently fetch all transactions returned.
        */
       other_transactions?: /* The transaction_identifier uniquely identifies a transaction in a particular network and block or in the mempool. */ TransactionIdentifier[];
+    }
+    /**
+     * BlockTransaction contains a populated Transaction and the BlockIdentifier that contains it.
+     */
+    export interface BlockTransaction {
+      block_identifier: /* The block_identifier uniquely identifies a block in a particular network. */ BlockIdentifier;
+      transaction: /* Transactions contain an array of Operations that are attributable to the same TransactionIdentifier. */ Transaction;
     }
     /**
      * A BlockTransactionRequest is used to fetch a Transaction included in a block that is not returned in a BlockResponse.
@@ -167,12 +254,52 @@ declare namespace Components {
       transaction: /* Transactions contain an array of Operations that are attributable to the same TransactionIdentifier. */ Transaction;
     }
     /**
+     * CallRequest is the input to the `/call` endpoint.
+     */
+    export interface CallRequest {
+      network_identifier: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
+      /**
+       * Method is some network-specific procedure call. This method could map to a network-specific RPC endpoint, a method in an SDK generated from a smart contract, or some hybrid of the two. The implementation must define all available methods in the Allow object. However, it is up to the caller to determine which parameters to provide when invoking `/call`.
+       * example:
+       * eth_call
+       */
+      method: string;
+      /**
+       * Parameters is some network-specific argument for a method. It is up to the caller to determine which parameters to provide when invoking `/call`.
+       * example:
+       * {
+       *   "block_number": 23,
+       *   "address": "0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5"
+       * }
+       */
+      parameters: {};
+    }
+    /**
+     * CallResponse contains the result of a `/call` invocation.
+     */
+    export interface CallResponse {
+      /**
+       * Result contains the result of the `/call` invocation. This result will not be inspected or interpreted by Rosetta tooling and is left to the caller to decode.
+       * example:
+       * {
+       *   "count": 1000
+       * }
+       */
+      result: {};
+      /**
+       * Idempotent indicates that if `/call` is invoked with the same CallRequest again, at any point in time, it will return the same CallResponse. Integrators may cache the CallResponse if this is set to true to avoid making unnecessary calls to the Rosetta implementation. For this reason, implementers should be very conservative about returning true here or they could cause issues for the caller.
+       */
+      idempotent: boolean;
+    }
+    /**
      * Coin contains its unique identifier and the amount it represents.
      */
     export interface Coin {
       coin_identifier: /* CoinIdentifier uniquely identifies a Coin. */ CoinIdentifier;
       amount: /* Amount is some Value of a Currency. It is considered invalid to specify a Value without a Currency. */ Amount;
-      metadata?: any;
+      metadata?: {
+        [name: string]: TokenBundleItem[];
+      };
     }
     /**
      * CoinActions are different state changes that a Coin can undergo. When a Coin is created, it is coin_created. When a Coin is spent, it is coin_spent. It is assumed that a single Coin cannot be created or spent more than once.
@@ -240,14 +367,14 @@ declare namespace Components {
       signed_transaction: string;
     }
     /**
-     * A ConstructionMetadataRequest is utilized to get information required to construct a transaction. The Options object used to specify which metadata to return is left purposely unstructured to allow flexibility for implementers. Optionally, the request can also include an array of PublicKeys associated with the AccountIdentifiers returned in ConstructionPreprocessResponse.
+     * A ConstructionMetadataRequest is utilized to get information required to construct a transaction. The Options object used to specify which metadata to return is left purposely unstructured to allow flexibility for implementers. Options is not required in the case that there is network-wide metadata of interest. Optionally, the request can also include an array of PublicKeys associated with the AccountIdentifiers returned in ConstructionPreprocessResponse.
      */
     export interface ConstructionMetadataRequest {
       network_identifier: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
       /**
        * Some blockchains require different metadata for different types of transaction construction (ex: delegation versus a transfer). Instead of requiring a blockchain node to return all possible types of metadata for construction (which may require multiple node fetches), the client can populate an options object to limit the metadata returned to only the subset required.
        */
-      options: {
+      options?: {
         relative_ttl: number;
         transaction_size: number;
       };
@@ -287,7 +414,7 @@ declare namespace Components {
      * ConstructionParseResponse contains an array of operations that occur in a transaction blob. This should match the array of operations provided to `/construction/preprocess` and `/construction/payloads`.
      */
     export interface ConstructionParseResponse {
-      operations: /* Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction. */ Operation[];
+      operations: /* Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction. Operations are used both to represent on-chain data (Data API) and to construct new transactions (Construction API), creating a standard interface for reading and writing to blockchains. */ Operation[];
       /**
        * [DEPRECATED by `account_identifier_signers` in `v1.4.4`] All signers (addresses) of a particular transaction. If the transaction is unsigned, it should be empty.
        */
@@ -300,10 +427,8 @@ declare namespace Components {
      */
     export interface ConstructionPayloadsRequest {
       network_identifier: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
-      operations: /* Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction. */ Operation[];
-      metadata: {
-        ttl: string;
-      };
+      operations: /* Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction. Operations are used both to represent on-chain data (Data API) and to construct new transactions (Construction API), creating a standard interface for reading and writing to blockchains. */ Operation[];
+      metadata?: {};
       public_keys?: /* PublicKey contains a public key byte array for a particular CurveType encoded in hex. Note that there is no PrivateKey struct as this is NEVER the concern of an implementation. */ PublicKey[];
     }
     /**
@@ -318,7 +443,7 @@ declare namespace Components {
      */
     export interface ConstructionPreprocessRequest {
       network_identifier: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
-      operations: /* Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction. */ Operation[];
+      operations: /* Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction. Operations are used both to represent on-chain data (Data API) and to construct new transactions (Construction API), creating a standard interface for reading and writing to blockchains. */ Operation[];
       metadata?: {
         relative_ttl: number;
       };
@@ -361,12 +486,23 @@ declare namespace Components {
        * 8
        */
       decimals: number; // int32
-      metadata?: any;
+      /**
+       * Any additional information related to the currency itself. For example, it would be useful to populate this object with the contract address of an ERC-20 token.
+       * example:
+       * {
+       *   "Issuer": "Satoshi"
+       * }
+       */
+      metadata?: {};
     }
     /**
      * CurveType is the type of cryptographic curve associated with a PublicKey. * secp256k1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * secp256r1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * edwards25519: `y (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf) * tweedle: 1st pk : Fq.t (32 bytes) || 2nd pk : Fq.t (32 bytes) (https://github.com/CodaProtocol/coda/blob/develop/rfcs/0038-rosetta-construction-api.md#marshal-keys)
      */
     export type CurveType = 'secp256k1' | 'secp256r1' | 'edwards25519' | 'tweedle';
+    /**
+     * Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may reference `backward` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if a transaction relation is from child to parent or the reverse.
+     */
+    export type Direction = 'forward' | 'backward';
     /**
      * Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields.
      */
@@ -384,6 +520,12 @@ declare namespace Components {
        */
       message: string;
       /**
+       * Description allows the implementer to optionally provide additional information about an error. In many cases, the content of this field will be a copy-and-paste from existing developer documentation. Description can ONLY be populated with generic information about a particular type of error. It MUST NOT be populated with information about a particular instantiation of an error (use `details` for this). Whereas the content of Error.Message should stay stable across releases, the content of Error.Description will likely change across releases (as implementers improve error documentation). For this reason, the content in this field is not part of any type assertion (unlike Error.Message).
+       * example:
+       * This error is returned when the requested AccountIdentifier is improperly formatted.
+       */
+      description?: string;
+      /**
        * An error is retriable if the same request may succeed if submitted again.
        */
       retriable: boolean;
@@ -399,6 +541,43 @@ declare namespace Components {
         message: string;
       };
     }
+    /**
+     * EventsBlocksRequest is utilized to fetch a sequence of BlockEvents indicating which blocks were added and removed from storage to reach the current state.
+     */
+    export interface EventsBlocksRequest {
+      network_identifier: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
+      /**
+       * offset is the offset into the event stream to sync events from. If this field is not populated, we return the limit events backwards from tip. If this is set to 0, we start from the beginning.
+       * example:
+       * 5
+       */
+      offset?: number; // int64
+      /**
+       * limit is the maximum number of events to fetch in one call. The implementation may return <= limit events.
+       * example:
+       * 5
+       */
+      limit?: number; // int64
+    }
+    /**
+     * EventsBlocksResponse contains an ordered collection of BlockEvents and the max retrievable sequence.
+     */
+    export interface EventsBlocksResponse {
+      /**
+       * max_sequence is the maximum available sequence number to fetch.
+       * example:
+       * 5
+       */
+      max_sequence: number; // int64
+      /**
+       * events is an array of BlockEvents indicating the order to add and remove blocks to maintain a canonical view of blockchain state. Lightweight clients can use this event stream to update state without implementing their own block syncing logic.
+       */
+      events: /* BlockEvent represents the addition or removal of a BlockIdentifier from storage. Streaming BlockEvents allows lightweight clients to update their own state without needing to implement their own syncing logic. */ BlockEvent[];
+    }
+    /**
+     * ExemptionType is used to indicate if the live balance for an account subject to a BalanceExemption could increase above, decrease below, or equal the computed balance. * greater_or_equal: The live balance may increase above or equal the computed balance. This typically   occurs with staking rewards that accrue on each block. * less_or_equal: The live balance may decrease below or equal the computed balance. This typically   occurs as balance moves from locked to spendable on a vesting account. * dynamic: The live balance may increase above, decrease below, or equal the computed balance. This   typically occurs with tokens that have a dynamic supply.
+     */
+    export type ExemptionType = 'greater_or_equal' | 'less_or_equal' | 'dynamic';
     /**
      * A MempoolResponse contains all transaction identifiers in the mempool for a particular network_identifier.
      */
@@ -482,16 +661,16 @@ declare namespace Components {
       Timestamp /* int64 */;
       genesis_block_identifier: /* The block_identifier uniquely identifies a block in a particular network. */ BlockIdentifier;
       oldest_block_identifier?: /* The block_identifier uniquely identifies a block in a particular network. */ BlockIdentifier;
-      sync_status?: /* SyncStatus is used to provide additional context about an implementation's sync status. It is often used to indicate that an implementation is healthy when it cannot be queried  until some sync phase occurs. If an implementation is immediately queryable, this model is often not populated. */ SyncStatus;
+      sync_status?: /* SyncStatus is used to provide additional context about an implementation's sync status. This object is often used by implementations to indicate healthiness when block data cannot be queried until some sync phase completes or cannot be determined by comparing the timestamp of the most recent block with the current time. */ SyncStatus;
       peers: /* A Peer is a representation of a node's peer. */ Peer[];
     }
     /**
-     * Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction.
+     * Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction. Operations are used both to represent on-chain data (Data API) and to construct new transactions (Construction API), creating a standard interface for reading and writing to blockchains.
      */
     export interface Operation {
       operation_identifier: /* The operation_identifier uniquely identifies an operation within a transaction. */ OperationIdentifier;
       /**
-       * Restrict referenced related_operations to identifier indexes < the current operation_identifier.index. This ensures there exists a clear DAG-structure of relations. Since operations are one-sided, one could imagine relating operations in a single transfer or linking operations in a call tree.
+       * Restrict referenced related_operations to identifier indices < the current operation_identifier.index. This ensures there exists a clear DAG-structure of relations. Since operations are one-sided, one could imagine relating operations in a single transfer or linking operations in a call tree.
        * example:
        * [
        *   {
@@ -504,17 +683,17 @@ declare namespace Components {
        */
       related_operations?: /* The operation_identifier uniquely identifies an operation within a transaction. */ OperationIdentifier[];
       /**
-       * The network-specific type of the operation. Ensure that any type that can be returned here is also specified in the NetworkOptionsResponse. This can be very useful to downstream consumers that parse all block data.
+       * Type is the network-specific type of the operation. Ensure that any type that can be returned here is also specified in the NetworkOptionsResponse. This can be very useful to downstream consumers that parse all block data.
        * example:
        * Transfer
        */
       type: string;
       /**
-       * The network-specific status of the operation. Status is not defined on the transaction object because blockchains with smart contracts may have transactions that partially apply. Blockchains with atomic transactions (all operations succeed or all operations fail) will have the same status for each operation.
+       * Status is the network-specific status of the operation. Status is not defined on the transaction object because blockchains with smart contracts may have transactions that partially apply (some operations are successful and some are not). Blockchains with atomic transactions (all operations succeed or all operations fail) will have the same status for each operation. On-chain operations (operations retrieved in the `/block` and `/block/transaction` endpoints) MUST have a populated status field (anything on-chain must have succeeded or failed). However, operations provided during transaction construction (often times called "intent" in the documentation) MUST NOT have a populated status field (operations yet to be included on-chain have not yet succeeded or failed).
        * example:
        * Reverted
        */
-      status: string;
+      status?: string;
       account?: /* The account_identifier uniquely identifies an account within a network. All fields in the account_identifier are utilized to determine this uniqueness (including the metadata field, if populated). */ AccountIdentifier;
       amount?: /* Amount is some Value of a Currency. It is considered invalid to specify a Value without a Currency. */ Amount;
       coin_change?: /* CoinChange is used to represent a change in state of a some coin identified by a coin_identifier. This object is part of the Operation model and must be populated for UTXO-based blockchains. Coincidentally, this abstraction of UTXOs allows for supporting both account-based transfers and UTXO-based transfers on the same blockchain (when a transfer is account-based, don't populate this model). */ CoinChange;
@@ -594,6 +773,10 @@ declare namespace Components {
       successful: boolean;
     }
     /**
+     * Operator is used by query-related endpoints to determine how to apply conditions. If this field is not populated, the default `and` value will be used.
+     */
+    export type Operator = 'or' | 'and';
+    /**
      * When fetching data by BlockIdentifier, it may be possible to only specify the index or hash. If neither property is specified, it is assumed that the client is making a request at the current block.
      */
     export interface PartialBlockIdentifier {
@@ -628,6 +811,86 @@ declare namespace Components {
        */
       hex_bytes: string;
       curve_type: /* CurveType is the type of cryptographic curve associated with a PublicKey. * secp256k1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * secp256r1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * edwards25519: `y (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf) * tweedle: 1st pk : Fq.t (32 bytes) || 2nd pk : Fq.t (32 bytes) (https://github.com/CodaProtocol/coda/blob/develop/rfcs/0038-rosetta-construction-api.md#marshal-keys) */ CurveType;
+    }
+    /**
+     * The related_transaction allows implementations to link together multiple transactions. An unpopulated network identifier indicates that the related transaction is on the same network.
+     */
+    export interface RelatedTransaction {
+      network_identifier?: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
+      transaction_identifier: /* The transaction_identifier uniquely identifies a transaction in a particular network and block or in the mempool. */ TransactionIdentifier;
+      direction: /* Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may reference `backward` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if a transaction relation is from child to parent or the reverse. */ Direction;
+    }
+    /**
+     * SearchTransactionsRequest is used to search for transactions matching a set of provided conditions in canonical blocks.
+     */
+    export interface SearchTransactionsRequest {
+      network_identifier: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
+      operator?: /* Operator is used by query-related endpoints to determine how to apply conditions. If this field is not populated, the default `and` value will be used. */ Operator;
+      /**
+       * max_block is the largest block index to consider when searching for transactions. If this field is not populated, the current block is considered the max_block. If you do not specify a max_block, it is possible a newly synced block will interfere with paginated transaction queries (as the offset could become invalid with newly added rows).
+       * example:
+       * 5
+       */
+      max_block?: number; // int64
+      /**
+       * offset is the offset into the query result to start returning transactions. If any search conditions are changed, the query offset will change and you must restart your search iteration.
+       * example:
+       * 5
+       */
+      offset?: number; // int64
+      /**
+       * limit is the maximum number of transactions to return in one call. The implementation may return <= limit transactions.
+       * example:
+       * 5
+       */
+      limit?: number; // int64
+      transaction_identifier?: /* The transaction_identifier uniquely identifies a transaction in a particular network and block or in the mempool. */ TransactionIdentifier;
+      account_identifier?: /* The account_identifier uniquely identifies an account within a network. All fields in the account_identifier are utilized to determine this uniqueness (including the metadata field, if populated). */ AccountIdentifier;
+      coin_identifier?: /* CoinIdentifier uniquely identifies a Coin. */ CoinIdentifier;
+      currency?: /* Currency is composed of a canonical Symbol and Decimals. This Decimals value is used to convert an Amount.Value from atomic units (Satoshis) to standard units (Bitcoins). */ Currency;
+      /**
+       * status is the network-specific operation type.
+       * example:
+       * reverted
+       */
+      status?: string;
+      /**
+       * type is the network-specific operation type.
+       * example:
+       * transfer
+       */
+      type?: string;
+      /**
+       * address is AccountIdentifier.Address. This is used to get all transactions related to an AccountIdentifier.Address, regardless of SubAccountIdentifier.
+       * example:
+       * 0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347
+       */
+      address?: string;
+      /**
+       * success is a synthetic condition populated by parsing network-specific operation statuses (using the mapping provided in `/network/options`).
+       */
+      success?: boolean;
+    }
+    /**
+     * SearchTransactionsResponse contains an ordered collection of BlockTransactions that match the query in SearchTransactionsRequest. These BlockTransactions are sorted from most recent block to oldest block.
+     */
+    export interface SearchTransactionsResponse {
+      /**
+       * transactions is an array of BlockTransactions sorted by most recent BlockIdentifier (meaning that transactions in recent blocks appear first). If there are many transactions for a particular search, transactions may not contain all matching transactions. It is up to the caller to paginate these transactions using the max_block field.
+       */
+      transactions: /* BlockTransaction contains a populated Transaction and the BlockIdentifier that contains it. */ BlockTransaction[];
+      /**
+       * total_count is the number of results for a given search. Callers typically use this value to concurrently fetch results by offset or to display a virtual page number associated with results.
+       * example:
+       * 5
+       */
+      total_count: number; // int64
+      /**
+       * next_offset is the next offset to use when paginating through transaction results. If this field is not populated, there are no more transactions to query.
+       * example:
+       * 5
+       */
+      next_offset?: number; // int64
     }
     /**
      * Signature contains the payload that was signed, the public keys of the keypairs used to produce the signature, the signature (encoded in hex), and the SignatureType. PublicKey is often times not known during construction of the signing payloads but may be needed to combine signatures properly.
@@ -687,15 +950,15 @@ declare namespace Components {
       metadata?: {};
     }
     /**
-     * SyncStatus is used to provide additional context about an implementation's sync status. It is often used to indicate that an implementation is healthy when it cannot be queried  until some sync phase occurs. If an implementation is immediately queryable, this model is often not populated.
+     * SyncStatus is used to provide additional context about an implementation's sync status. This object is often used by implementations to indicate healthiness when block data cannot be queried until some sync phase completes or cannot be determined by comparing the timestamp of the most recent block with the current time.
      */
     export interface SyncStatus {
       /**
-       * CurrentIndex is the index of the last synced block in the current stage.
+       * CurrentIndex is the index of the last synced block in the current stage. This is a separate field from current_block_identifier in NetworkStatusResponse because blocks with indices up to and including the current_index may not yet be queryable by the caller. To reiterate, all indices up to and including current_block_identifier in NetworkStatusResponse must be queryable via the /block endpoint (excluding indices less than oldest_block_identifier).
        * example:
        * 100
        */
-      current_index: number; // int64
+      current_index?: number; // int64
       /**
        * TargetIndex is the index of the block that the implementation is attempting to sync to in the current stage.
        * example:
@@ -708,6 +971,10 @@ declare namespace Components {
        * header sync
        */
       stage?: string;
+      /**
+       * sycned is a boolean that indicates if an implementation has synced up to the most recent block. If this field is not populated, the caller should rely on a traditional tip timestamp comparison to determine if an implementation is synced. This field is particularly useful for quiescent blockchains (blocks only produced when there are pending transactions). In these blockchains, the most recent block could have a timestamp far behind the current time but the node could be healthy and at tip.
+       */
+      synced?: boolean;
     }
     /**
      * The timestamp of the block in milliseconds since the Unix Epoch. The timestamp is stored in milliseconds because some blockchains produce blocks more often than once a second.
@@ -727,7 +994,8 @@ declare namespace Components {
      */
     export interface Transaction {
       transaction_identifier: /* The transaction_identifier uniquely identifies a transaction in a particular network and block or in the mempool. */ TransactionIdentifier;
-      operations: /* Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction. */ Operation[];
+      operations: /* Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction. Operations are used both to represent on-chain data (Data API) and to construct new transactions (Construction API), creating a standard interface for reading and writing to blockchains. */ Operation[];
+      related_transactions?: /* The related_transaction allows implementations to link together multiple transactions. An unpopulated network identifier indicates that the related transaction is on the same network. */ RelatedTransaction[];
       /**
        * Transactions that are related to other transactions (like a cross-shard transaction) should include the tranaction_identifier of these transactions in the metadata.
        * example:
@@ -797,14 +1065,21 @@ declare namespace Paths {
   namespace AccountBalance {
     export type RequestBody = /* An AccountBalanceRequest is utilized to make a balance request on the /account/balance endpoint. If the block_identifier is populated, a historical balance query should be performed. */ Components.Schemas.AccountBalanceRequest;
     namespace Responses {
-      export type $200 = /* An AccountBalanceResponse is returned on the /account/balance endpoint. If an account has a balance for each AccountIdentifier describing it (ex: an ERC-20 token balance on a few smart contracts), an account balance request must be made with each AccountIdentifier. */ Components.Schemas.AccountBalanceResponse;
+      export type $200 = /* An AccountBalanceResponse is returned on the /account/balance endpoint. If an account has a balance for each AccountIdentifier describing it (ex: an ERC-20 token balance on a few smart contracts), an account balance request must be made with each AccountIdentifier. The `coins` field was removed and replaced by by `/account/coins` in `v1.4.7`. */ Components.Schemas.AccountBalanceResponse;
+      export type $500 = /* Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields. */ Components.Schemas.Error;
+    }
+  }
+  namespace AccountCoins {
+    export type RequestBody = /* AccountCoinsRequest is utilized to make a request on the /account/coins endpoint. */ Components.Schemas.AccountCoinsRequest;
+    namespace Responses {
+      export type $200 = /* AccountCoinsResponse is returned on the /account/coins endpoint and includes all unspent Coins owned by an AccountIdentifier. */ Components.Schemas.AccountCoinsResponse;
       export type $500 = /* Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields. */ Components.Schemas.Error;
     }
   }
   namespace Block {
     export type RequestBody = /* A BlockRequest is utilized to make a block request on the /block endpoint. */ Components.Schemas.BlockRequest;
     namespace Responses {
-      export type $200 = /* A BlockResponse includes a fully-populated block or a partially-populated block with a list of other transactions to fetch (other_transactions). As a result of the consensus algorithm of some blockchains, blocks can be omitted (i.e. certain block indexes can be skipped). If a query for one of these omitted indexes is made, the response should not include a `Block` object. It is VERY important to note that blocks MUST still form a canonical, connected chain of blocks where each block has a unique index. In other words, the `PartialBlockIdentifier` of a block after an omitted block should reference the last non-omitted block. */ Components.Schemas.BlockResponse;
+      export type $200 = /* A BlockResponse includes a fully-populated block or a partially-populated block with a list of other transactions to fetch (other_transactions). As a result of the consensus algorithm of some blockchains, blocks can be omitted (i.e. certain block indices can be skipped). If a query for one of these omitted indices is made, the response should not include a `Block` object. It is VERY important to note that blocks MUST still form a canonical, connected chain of blocks where each block has a unique index. In other words, the `PartialBlockIdentifier` of a block after an omitted block should reference the last non-omitted block. */ Components.Schemas.BlockResponse;
       export type $500 = /* Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields. */ Components.Schemas.Error;
     }
   }
@@ -812,6 +1087,13 @@ declare namespace Paths {
     export type RequestBody = /* A BlockTransactionRequest is used to fetch a Transaction included in a block that is not returned in a BlockResponse. */ Components.Schemas.BlockTransactionRequest;
     namespace Responses {
       export type $200 = /* A BlockTransactionResponse contains information about a block transaction. */ Components.Schemas.BlockTransactionResponse;
+      export type $500 = /* Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields. */ Components.Schemas.Error;
+    }
+  }
+  namespace Call {
+    export type RequestBody = /* CallRequest is the input to the `/call` endpoint. */ Components.Schemas.CallRequest;
+    namespace Responses {
+      export type $200 = /* CallResponse contains the result of a `/call` invocation. */ Components.Schemas.CallResponse;
       export type $500 = /* Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields. */ Components.Schemas.Error;
     }
   }
@@ -837,7 +1119,7 @@ declare namespace Paths {
     }
   }
   namespace ConstructionMetadata {
-    export type RequestBody = /* A ConstructionMetadataRequest is utilized to get information required to construct a transaction. The Options object used to specify which metadata to return is left purposely unstructured to allow flexibility for implementers. Optionally, the request can also include an array of PublicKeys associated with the AccountIdentifiers returned in ConstructionPreprocessResponse. */ Components.Schemas.ConstructionMetadataRequest;
+    export type RequestBody = /* A ConstructionMetadataRequest is utilized to get information required to construct a transaction. The Options object used to specify which metadata to return is left purposely unstructured to allow flexibility for implementers. Options is not required in the case that there is network-wide metadata of interest. Optionally, the request can also include an array of PublicKeys associated with the AccountIdentifiers returned in ConstructionPreprocessResponse. */ Components.Schemas.ConstructionMetadataRequest;
     namespace Responses {
       export type $200 = /* The ConstructionMetadataResponse returns network-specific metadata used for transaction construction. Optionally, the implementer can return the suggested fee associated with the transaction being constructed. The caller may use this info to adjust the intent of the transaction or to create a transaction with a different account that can pay the suggested fee. Suggested fee is an array in case fee payment must occur in multiple currencies. */ Components.Schemas.ConstructionMetadataResponse;
       export type $500 = /* Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields. */ Components.Schemas.Error;
@@ -868,6 +1150,13 @@ declare namespace Paths {
     export type RequestBody = /* The transaction submission request includes a signed transaction. */ Components.Schemas.ConstructionSubmitRequest;
     namespace Responses {
       export type $200 = /* TransactionIdentifierResponse contains the transaction_identifier of a transaction that was submitted to either `/construction/hash` or `/construction/submit`. */ Components.Schemas.TransactionIdentifierResponse;
+      export type $500 = /* Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields. */ Components.Schemas.Error;
+    }
+  }
+  namespace EventsBlocks {
+    export type RequestBody = /* EventsBlocksRequest is utilized to fetch a sequence of BlockEvents indicating which blocks were added and removed from storage to reach the current state. */ Components.Schemas.EventsBlocksRequest;
+    namespace Responses {
+      export type $200 = /* EventsBlocksResponse contains an ordered collection of BlockEvents and the max retrievable sequence. */ Components.Schemas.EventsBlocksResponse;
       export type $500 = /* Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields. */ Components.Schemas.Error;
     }
   }
@@ -903,6 +1192,13 @@ declare namespace Paths {
     export type RequestBody = /* A NetworkRequest is utilized to retrieve some data specific exclusively to a NetworkIdentifier. */ Components.Schemas.NetworkRequest;
     namespace Responses {
       export type $200 = /* NetworkStatusResponse contains basic information about the node's view of a blockchain network. It is assumed that any BlockIdentifier.Index less than or equal to CurrentBlockIdentifier.Index can be queried. If a Rosetta implementation prunes historical state, it should populate the optional `oldest_block_identifier` field with the oldest block available to query. If this is not populated, it is assumed that the `genesis_block_identifier` is the oldest queryable block. If a Rosetta implementation performs some pre-sync before it is possible to query blocks, sync_status should be populated so that clients can still monitor healthiness. Without this field, it may appear that the implementation is stuck syncing and needs to be terminated. */ Components.Schemas.NetworkStatusResponse;
+      export type $500 = /* Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields. */ Components.Schemas.Error;
+    }
+  }
+  namespace SearchTransactions {
+    export type RequestBody = /* SearchTransactionsRequest is used to search for transactions matching a set of provided conditions in canonical blocks. */ Components.Schemas.SearchTransactionsRequest;
+    namespace Responses {
+      export type $200 = /* SearchTransactionsResponse contains an ordered collection of BlockTransactions that match the query in SearchTransactionsRequest. These BlockTransactions are sorted from most recent block to oldest block. */ Components.Schemas.SearchTransactionsResponse;
       export type $500 = /* Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields. */ Components.Schemas.Error;
     }
   }

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -374,7 +374,7 @@ declare namespace Components {
       /**
        * Some blockchains require different metadata for different types of transaction construction (ex: delegation versus a transfer). Instead of requiring a blockchain node to return all possible types of metadata for construction (which may require multiple node fetches), the client can populate an options object to limit the metadata returned to only the subset required.
        */
-      options?: {
+      options: {
         relative_ttl: number;
         transaction_size: number;
       };
@@ -428,7 +428,9 @@ declare namespace Components {
     export interface ConstructionPayloadsRequest {
       network_identifier: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
       operations: /* Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction. Operations are used both to represent on-chain data (Data API) and to construct new transactions (Construction API), creating a standard interface for reading and writing to blockchains. */ Operation[];
-      metadata?: {};
+      metadata: {
+        ttl: string;
+      };
       public_keys?: /* PublicKey contains a public key byte array for a particular CurveType encoded in hex. Note that there is no PrivateKey struct as this is NEVER the concern of an implementation. */ PublicKey[];
     }
     /**
@@ -486,14 +488,7 @@ declare namespace Components {
        * 8
        */
       decimals: number; // int32
-      /**
-       * Any additional information related to the currency itself. For example, it would be useful to populate this object with the contract address of an ERC-20 token.
-       * example:
-       * {
-       *   "Issuer": "Satoshi"
-       * }
-       */
-      metadata?: {};
+      metadata?: any;
     }
     /**
      * CurveType is the type of cryptographic curve associated with a PublicKey. * secp256k1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * secp256r1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * edwards25519: `y (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf) * tweedle: 1st pk : Fq.t (32 bytes) || 2nd pk : Fq.t (32 bytes) (https://github.com/CodaProtocol/coda/blob/develop/rfcs/0038-rosetta-construction-api.md#marshal-keys)

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -355,8 +355,8 @@ declare namespace Components {
       /**
        * [DEPRECATED by `account_identifier` in `v1.4.4`] Address in network-specific format.
        */
-      address: string;
-      account_identifier?: /* The account_identifier uniquely identifies an account within a network. All fields in the account_identifier are utilized to determine this uniqueness (including the metadata field, if populated). */ AccountIdentifier;
+      address?: string;
+      account_identifier: /* The account_identifier uniquely identifies an account within a network. All fields in the account_identifier are utilized to determine this uniqueness (including the metadata field, if populated). */ AccountIdentifier;
       metadata?: {};
     }
     /**
@@ -418,8 +418,8 @@ declare namespace Components {
       /**
        * [DEPRECATED by `account_identifier_signers` in `v1.4.4`] All signers (addresses) of a particular transaction. If the transaction is unsigned, it should be empty.
        */
-      signers: string[];
-      account_identifier_signers?: /* The account_identifier uniquely identifies an account within a network. All fields in the account_identifier are utilized to determine this uniqueness (including the metadata field, if populated). */ AccountIdentifier[];
+      signers?: string[];
+      account_identifier_signers: /* The account_identifier uniquely identifies an account within a network. All fields in the account_identifier are utilized to determine this uniqueness (including the metadata field, if populated). */ AccountIdentifier[];
       metadata?: {};
     }
     /**

--- a/cardano-rosetta-server/test/e2e/account/account-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-api.test.ts
@@ -80,13 +80,13 @@ describe('/account/balance endpoint', () => {
     expect(response.statusCode).toEqual(StatusCodes.OK);
     expect(response.json()).toEqual({
       balances: [{ currency: { decimals: 6, symbol: 'ADA' }, value: '21063' }],
-      block_identifier: latestBlockIdentifier,
-      coins: [
-        {
-          coin_identifier: { identifier: 'af0dd90debb1fbaf3854b90686ba2d6f7c95416080e8cda18d9ea3cb6bb195ad:0' },
-          amount: { value: '21063', currency: { symbol: 'ADA', decimals: 6 } }
-        }
-      ]
+      block_identifier: latestBlockIdentifier
+      // coins: [
+      //   {
+      //     coin_identifier: { identifier: 'af0dd90debb1fbaf3854b90686ba2d6f7c95416080e8cda18d9ea3cb6bb195ad:0' },
+      //     amount: { value: '21063', currency: { symbol: 'ADA', decimals: 6 } }
+      //   }
+      // ]
     });
   });
 
@@ -102,8 +102,8 @@ describe('/account/balance endpoint', () => {
       block_identifier: {
         hash: '7c6901c6346781c2bc5cbc49577490e336c2545c320ce4a61605bc71a9c5bed0',
         index: 20
-      },
-      coins: AE2HashAccountUtxos
+      }
+      // coins: AE2HashAccountUtxos
     });
   });
 
@@ -125,8 +125,8 @@ describe('/account/balance endpoint', () => {
       block_identifier: {
         hash: '7c6901c6346781c2bc5cbc49577490e336c2545c320ce4a61605bc71a9c5bed0',
         index: 20
-      },
-      coins: AE2HashAccountUtxos
+      }
+      // coins: AE2HashAccountUtxos
     });
   });
 
@@ -148,8 +148,8 @@ describe('/account/balance endpoint', () => {
       block_identifier: {
         hash: 'd3fdc8c8ea4050cc87a21cb73110d54e3ec92f8ae76941e8a1957ed6e6a7e0b0',
         index: 30
-      },
-      coins: AE2HashAccountUtxos
+      }
+      // coins: AE2HashAccountUtxos
     });
   });
 
@@ -190,21 +190,21 @@ describe('/account/balance endpoint', () => {
             symbol: 'ADA'
           }
         }
-      ],
-      coins: [
-        {
-          coin_identifier: {
-            identifier: '4bcf79c0c2967986749fd0ae03f5b54a712d51b35672a3d974707c060c4d8dac:1'
-          },
-          amount: { value: '10509579714', currency: { decimals: 6, symbol: 'ADA' } }
-        },
-        {
-          coin_identifier: {
-            identifier: 'bcc57134d1bd588b00f40142f0fdc17db5f35047e3196cdf26aa7319524c0014:1'
-          },
-          amount: { value: '999800000', currency: { decimals: 6, symbol: 'ADA' } }
-        }
       ]
+      // coins: [
+      //   {
+      //     coin_identifier: {
+      //       identifier: '4bcf79c0c2967986749fd0ae03f5b54a712d51b35672a3d974707c060c4d8dac:1'
+      //     },
+      //     amount: { value: '10509579714', currency: { decimals: 6, symbol: 'ADA' } }
+      //   },
+      //   {
+      //     coin_identifier: {
+      //       identifier: 'bcc57134d1bd588b00f40142f0fdc17db5f35047e3196cdf26aa7319524c0014:1'
+      //     },
+      //     amount: { value: '999800000', currency: { decimals: 6, symbol: 'ADA' } }
+      //   }
+      // ]
     });
   });
 
@@ -250,13 +250,13 @@ describe('/account/balance endpoint', () => {
             symbol: 'ADA'
           }
         }
-      ],
-      coins: [
-        {
-          amount: { value: '1000000', currency: { symbol: 'ADA', decimals: 6 } },
-          coin_identifier: { identifier: '6497b33b10fa2619c6efbd9f874ecd1c91badb10bf70850732aab45b90524d9e:0' }
-        }
       ]
+      // coins: [
+      //   {
+      //     amount: { value: '1000000', currency: { symbol: 'ADA', decimals: 6 } },
+      //     coin_identifier: { identifier: '6497b33b10fa2619c6efbd9f874ecd1c91badb10bf70850732aab45b90524d9e:0' }
+      //   }
+      // ]
     });
   });
   test('should only consider balance till last block and balance SHOULD be 0', async () => {
@@ -284,8 +284,8 @@ describe('/account/balance endpoint', () => {
             symbol: 'ADA'
           }
         }
-      ],
-      coins: []
+      ]
+      // coins: []
     });
   });
   test('should return 0 for the balance of stake account at block with no earned rewards', async () => {
@@ -392,8 +392,8 @@ describe('/account/balance endpoint', () => {
     address1vpfAccountBalances.forEach(accountBalance =>
       expect(response.json().balances).toContainEqual(accountBalance)
     );
-    expect(response.json().coins).toHaveLength(address1vpfCoins.length);
-    address1vpfCoins.forEach(address1vpfCoin => expect(response.json().coins).toContainEqual(address1vpfCoin));
+    // expect(response.json().coins).toHaveLength(address1vpfCoins.length);
+    // address1vpfCoins.forEach(address1vpfCoin => expect(response.json().coins).toContainEqual(address1vpfCoin));
   });
 
   // eslint-disable-next-line max-len
@@ -431,8 +431,8 @@ describe('/account/balance endpoint', () => {
     balancesAtBlock213891.forEach(accountBalance =>
       expect(responseAtBlock213891.json().balances).toContainEqual(accountBalance)
     );
-    expect(responseAtBlock213891.json().coins).toHaveLength(coinsAtBlock213891.length);
-    coinsAtBlock213891.forEach(coin => expect(responseAtBlock213891.json().coins).toContainEqual(coin));
+    // expect(responseAtBlock213891.json().coins).toHaveLength(coinsAtBlock213891.length);
+    // coinsAtBlock213891.forEach(coin => expect(responseAtBlock213891.json().coins).toContainEqual(coin));
     expect(responseAtBlock213892.statusCode).toEqual(StatusCodes.OK);
     expect(responseAtBlock213892.json().block_identifier).toEqual({
       index: 213892,
@@ -441,8 +441,8 @@ describe('/account/balance endpoint', () => {
     balancesAtBlock213892.forEach(accountBalance =>
       expect(responseAtBlock213892.json().balances).toContainEqual(accountBalance)
     );
-    expect(responseAtBlock213892.json().coins).toHaveLength(coinsAtBlock213892.length);
-    coinsAtBlock213892.forEach(coin => expect(responseAtBlock213892.json().coins).toContainEqual(coin));
+    // expect(responseAtBlock213892.json().coins).toHaveLength(coinsAtBlock213892.length);
+    // coinsAtBlock213892.forEach(coin => expect(responseAtBlock213892.json().coins).toContainEqual(coin));
   });
 
   test('should return balances for ma with empty name', async () => {
@@ -486,50 +486,50 @@ describe('/account/balance endpoint', () => {
             }
           }
         }
-      ],
-      coins: [
-        {
-          coin_identifier: { identifier: '02562c123f6d560e1250f5a46f7e95911b21fd8a9fa70157335c3a3d1d16bdda:0' },
-          amount: {
-            currency: { decimals: 6, symbol: 'ADA' },
-            value: '4800000'
-          },
-          metadata: {
-            '02562c123f6d560e1250f5a46f7e95911b21fd8a9fa70157335c3a3d1d16bdda:0': [
-              {
-                policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e',
-                tokens: [
-                  {
-                    value: '20',
-                    currency: {
-                      decimals: 0,
-                      symbol: '\\x',
-                      metadata: {
-                        policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d',
-                tokens: [
-                  {
-                    value: '10',
-                    currency: {
-                      decimals: 0,
-                      symbol: '7376c3a57274',
-                      metadata: {
-                        policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d'
-                      }
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        }
       ]
+      // coins: [
+      //   {
+      //     coin_identifier: { identifier: '02562c123f6d560e1250f5a46f7e95911b21fd8a9fa70157335c3a3d1d16bdda:0' },
+      //     amount: {
+      //       currency: { decimals: 6, symbol: 'ADA' },
+      //       value: '4800000'
+      //     },
+      //     metadata: {
+      //       '02562c123f6d560e1250f5a46f7e95911b21fd8a9fa70157335c3a3d1d16bdda:0': [
+      //         {
+      //           policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e',
+      //           tokens: [
+      //             {
+      //               value: '20',
+      //               currency: {
+      //                 decimals: 0,
+      //                 symbol: '\\x',
+      //                 metadata: {
+      //                   policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
+      //                 }
+      //               }
+      //             }
+      //           ]
+      //         },
+      //         {
+      //           policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d',
+      //           tokens: [
+      //             {
+      //               value: '10',
+      //               currency: {
+      //                 decimals: 0,
+      //                 symbol: '7376c3a57274',
+      //                 metadata: {
+      //                   policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d'
+      //                 }
+      //               }
+      //             }
+      //           ]
+      //         }
+      //       ]
+      //     }
+      //   }
+      // ]
     });
   });
 });

--- a/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
@@ -443,49 +443,6 @@ describe('/account/balance endpoint', () => {
           }
         }
       ]
-      // coins: [
-      //   {
-      //     coin_identifier: { identifier: '02562c123f6d560e1250f5a46f7e95911b21fd8a9fa70157335c3a3d1d16bdda:0' },
-      //     amount: {
-      //       currency: { decimals: 6, symbol: 'ADA' },
-      //       value: '4800000'
-      //     },
-      //     metadata: {
-      //       '02562c123f6d560e1250f5a46f7e95911b21fd8a9fa70157335c3a3d1d16bdda:0': [
-      //         {
-      //           policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e',
-      //           tokens: [
-      //             {
-      //               value: '20',
-      //               currency: {
-      //                 decimals: 0,
-      //                 symbol: '\\x',
-      //                 metadata: {
-      //                   policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
-      //                 }
-      //               }
-      //             }
-      //           ]
-      //         },
-      //         {
-      //           policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d',
-      //           tokens: [
-      //             {
-      //               value: '10',
-      //               currency: {
-      //                 decimals: 0,
-      //                 symbol: '7376c3a57274',
-      //                 metadata: {
-      //                   policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d'
-      //                 }
-      //               }
-      //             }
-      //           ]
-      //         }
-      //       ]
-      //     }
-      //   }
-      // ]
     });
   });
 });

--- a/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
@@ -7,11 +7,8 @@ import { CARDANO } from '../../../src/server/utils/constants';
 import {
   latestBlockIdentifier,
   address1vpfAccountBalances,
-  address1vpfCoins,
   balancesAtBlock213891,
-  balancesAtBlock213892,
-  coinsAtBlock213891,
-  coinsAtBlock213892
+  balancesAtBlock213892
 } from '../fixture-data';
 import { setupDatabase, setupServer } from '../utils/test-utils';
 
@@ -38,13 +35,6 @@ const AE2HashAccountBalances = [
       symbol: 'ADA'
     },
     value: '1153846000000'
-  }
-];
-
-const AE2HashAccountUtxos = [
-  {
-    coin_identifier: { identifier: '2d51b929d79a0ac8f360f38e8a38cdcb28ca84139aced314c5d7edc739aa4366:0' },
-    amount: { value: '1153846000000', currency: { symbol: 'ADA', decimals: 6 } }
   }
 ];
 
@@ -81,12 +71,6 @@ describe('/account/balance endpoint', () => {
     expect(response.json()).toEqual({
       balances: [{ currency: { decimals: 6, symbol: 'ADA' }, value: '21063' }],
       block_identifier: latestBlockIdentifier
-      // coins: [
-      //   {
-      //     coin_identifier: { identifier: 'af0dd90debb1fbaf3854b90686ba2d6f7c95416080e8cda18d9ea3cb6bb195ad:0' },
-      //     amount: { value: '21063', currency: { symbol: 'ADA', decimals: 6 } }
-      //   }
-      // ]
     });
   });
 
@@ -103,7 +87,6 @@ describe('/account/balance endpoint', () => {
         hash: '7c6901c6346781c2bc5cbc49577490e336c2545c320ce4a61605bc71a9c5bed0',
         index: 20
       }
-      // coins: AE2HashAccountUtxos
     });
   });
 
@@ -126,7 +109,6 @@ describe('/account/balance endpoint', () => {
         hash: '7c6901c6346781c2bc5cbc49577490e336c2545c320ce4a61605bc71a9c5bed0',
         index: 20
       }
-      // coins: AE2HashAccountUtxos
     });
   });
 
@@ -149,7 +131,6 @@ describe('/account/balance endpoint', () => {
         hash: 'd3fdc8c8ea4050cc87a21cb73110d54e3ec92f8ae76941e8a1957ed6e6a7e0b0',
         index: 30
       }
-      // coins: AE2HashAccountUtxos
     });
   });
 
@@ -191,20 +172,6 @@ describe('/account/balance endpoint', () => {
           }
         }
       ]
-      // coins: [
-      //   {
-      //     coin_identifier: {
-      //       identifier: '4bcf79c0c2967986749fd0ae03f5b54a712d51b35672a3d974707c060c4d8dac:1'
-      //     },
-      //     amount: { value: '10509579714', currency: { decimals: 6, symbol: 'ADA' } }
-      //   },
-      //   {
-      //     coin_identifier: {
-      //       identifier: 'bcc57134d1bd588b00f40142f0fdc17db5f35047e3196cdf26aa7319524c0014:1'
-      //     },
-      //     amount: { value: '999800000', currency: { decimals: 6, symbol: 'ADA' } }
-      //   }
-      // ]
     });
   });
 
@@ -251,12 +218,6 @@ describe('/account/balance endpoint', () => {
           }
         }
       ]
-      // coins: [
-      //   {
-      //     amount: { value: '1000000', currency: { symbol: 'ADA', decimals: 6 } },
-      //     coin_identifier: { identifier: '6497b33b10fa2619c6efbd9f874ecd1c91badb10bf70850732aab45b90524d9e:0' }
-      //   }
-      // ]
     });
   });
   test('should only consider balance till last block and balance SHOULD be 0', async () => {
@@ -285,7 +246,6 @@ describe('/account/balance endpoint', () => {
           }
         }
       ]
-      // coins: []
     });
   });
   test('should return 0 for the balance of stake account at block with no earned rewards', async () => {
@@ -392,8 +352,6 @@ describe('/account/balance endpoint', () => {
     address1vpfAccountBalances.forEach(accountBalance =>
       expect(response.json().balances).toContainEqual(accountBalance)
     );
-    // expect(response.json().coins).toHaveLength(address1vpfCoins.length);
-    // address1vpfCoins.forEach(address1vpfCoin => expect(response.json().coins).toContainEqual(address1vpfCoin));
   });
 
   // eslint-disable-next-line max-len
@@ -441,8 +399,6 @@ describe('/account/balance endpoint', () => {
     balancesAtBlock213892.forEach(accountBalance =>
       expect(responseAtBlock213892.json().balances).toContainEqual(accountBalance)
     );
-    // expect(responseAtBlock213892.json().coins).toHaveLength(coinsAtBlock213892.length);
-    // coinsAtBlock213892.forEach(coin => expect(responseAtBlock213892.json().coins).toContainEqual(coin));
   });
 
   test('should return balances for ma with empty name', async () => {

--- a/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
@@ -389,8 +389,6 @@ describe('/account/balance endpoint', () => {
     balancesAtBlock213891.forEach(accountBalance =>
       expect(responseAtBlock213891.json().balances).toContainEqual(accountBalance)
     );
-    // expect(responseAtBlock213891.json().coins).toHaveLength(coinsAtBlock213891.length);
-    // coinsAtBlock213891.forEach(coin => expect(responseAtBlock213891.json().coins).toContainEqual(coin));
     expect(responseAtBlock213892.statusCode).toEqual(StatusCodes.OK);
     expect(responseAtBlock213892.json().block_identifier).toEqual({
       index: 213892,

--- a/cardano-rosetta-server/test/e2e/account/account-coins-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-coins-api.test.ts
@@ -201,12 +201,12 @@ describe('/account/coins endpoint', () => {
     const response = await serverWithMultiassetsSupport.inject({
       method: 'post',
       url: ACCOUNT_COINS_ENDPOINT,
-      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vre2sc6w0zftnhselly9fd6kqqnmfmklful9zcmdh92mewszqs66y', [
+      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vpqwk50mnckqnjvzdd7lhln2685xep2xf84jmhd9njd5kucdqnufv', [
         {
           decimals: 0,
-          symbol: '486173414e616d65',
+          symbol: '4154414441636f696e',
           metadata: {
-            policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
+            policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
           }
         }
       ])
@@ -216,24 +216,59 @@ describe('/account/coins endpoint', () => {
       block_identifier: latestBlockIdentifierMAServer,
       coins: [
         {
-          coin_identifier: coinIdentifier95e1,
+          coin_identifier: { identifier: 'b352ea2f50d47851bda890ba2baed955f2f9aa3667ea69136454fa2a2de11ffe:0' },
           amount: {
-            currency: { decimals: 6, symbol: 'ADA' },
-            value: '4600000'
+            value: '5000000',
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            }
           },
           metadata: {
-            '95e1117558c2d075a4cd110ab0772460340f72a19ac5bc4691c6498e28055339:0': [
+            'b352ea2f50d47851bda890ba2baed955f2f9aa3667ea69136454fa2a2de11ffe:0': [
               {
-                policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e',
+                policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518',
                 tokens: [
                   {
-                    value: '30',
+                    value: '1',
                     currency: {
+                      symbol: '4154414441636f696e',
                       decimals: 0,
-                      symbol: '486173414e616d65',
-                      metadata: {
-                        policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
-                      }
+                      metadata: { policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518' }
+                    }
+                  },
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '61646f736961',
+                      decimals: 0,
+                      metadata: { policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518' }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd',
+                tokens: [
+                  {
+                    value: '2',
+                    currency: {
+                      symbol: '42435348',
+                      decimals: 0,
+                      metadata: { policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd' }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9',
+                tokens: [
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '676f6c64',
+                      decimals: 0,
+                      metadata: { policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9' }
                     }
                   }
                 ]
@@ -248,19 +283,19 @@ describe('/account/coins endpoint', () => {
     const response = await serverWithMultiassetsSupport.inject({
       method: 'post',
       url: ACCOUNT_COINS_ENDPOINT,
-      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vre2sc6w0zftnhselly9fd6kqqnmfmklful9zcmdh92mewszqs66y', [
+      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vpqwk50mnckqnjvzdd7lhln2685xep2xf84jmhd9njd5kucdqnufv', [
         {
           decimals: 0,
-          symbol: '486173414e616d65',
+          symbol: '4154414441636f696e',
           metadata: {
-            policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
+            policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
           }
         },
         {
           decimals: 0,
-          symbol: '7376c3a57274',
+          symbol: '676f6c64',
           metadata: {
-            policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d'
+            policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9'
           }
         }
       ])
@@ -270,39 +305,83 @@ describe('/account/coins endpoint', () => {
       block_identifier: latestBlockIdentifierMAServer,
       coins: [
         {
-          coin_identifier: coinIdentifier95e1,
+          coin_identifier: { identifier: 'b352ea2f50d47851bda890ba2baed955f2f9aa3667ea69136454fa2a2de11ffe:0' },
           amount: {
-            currency: { decimals: 6, symbol: 'ADA' },
-            value: '4600000'
+            value: '5000000',
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            }
           },
           metadata: {
-            '95e1117558c2d075a4cd110ab0772460340f72a19ac5bc4691c6498e28055339:0': [
+            'b352ea2f50d47851bda890ba2baed955f2f9aa3667ea69136454fa2a2de11ffe:0': [
               {
-                policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e',
+                policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518',
                 tokens: [
                   {
-                    value: '30',
+                    value: '1',
                     currency: {
+                      symbol: '4154414441636f696e',
                       decimals: 0,
-                      symbol: '486173414e616d65',
-                      metadata: {
-                        policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
-                      }
+                      metadata: { policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518' }
+                    }
+                  },
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '61646f736961',
+                      decimals: 0,
+                      metadata: { policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518' }
                     }
                   }
                 ]
               },
               {
-                policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d',
+                policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd',
                 tokens: [
                   {
-                    value: '10',
+                    value: '2',
                     currency: {
+                      symbol: '42435348',
                       decimals: 0,
-                      symbol: '7376c3a57274',
-                      metadata: {
-                        policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d'
-                      }
+                      metadata: { policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd' }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9',
+                tokens: [
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '676f6c64',
+                      decimals: 0,
+                      metadata: { policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9' }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          coin_identifier: { identifier: 'e58247e88790192246039816d27b58501c6686ab1f945cffec5262feedba4d23:0' },
+          amount: {
+            currency: { decimals: 6, symbol: 'ADA' },
+            value: '2000000'
+          },
+          metadata: {
+            'e58247e88790192246039816d27b58501c6686ab1f945cffec5262feedba4d23:0': [
+              {
+                policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9',
+                tokens: [
+                  {
+                    value: '5',
+                    currency: {
+                      symbol: '676f6c64',
+                      decimals: 0,
+                      metadata: { policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9' }
                     }
                   }
                 ]
@@ -349,6 +428,31 @@ describe('/account/coins endpoint', () => {
                       symbol: '\\x',
                       metadata: {
                         policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
+                      }
+                    }
+                  },
+                  {
+                    value: '30',
+                    currency: {
+                      decimals: 0,
+                      symbol: '486173414e616d65',
+                      metadata: {
+                        policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d',
+                tokens: [
+                  {
+                    value: '10',
+                    currency: {
+                      decimals: 0,
+                      symbol: '7376c3a57274',
+                      metadata: {
+                        policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d'
                       }
                     }
                   }
@@ -423,7 +527,6 @@ describe('/account/coins endpoint', () => {
         }
       ])
     });
-
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
     expect(response.json()).toEqual({
       code: 4023,

--- a/cardano-rosetta-server/test/e2e/account/account-coins-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-coins-api.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable unicorn/prevent-abbreviations */
 /* eslint-disable camelcase */
 /* eslint-disable no-magic-numbers */
@@ -392,6 +393,140 @@ describe('/account/coins endpoint', () => {
       ]
     });
   });
+  test('should return all coins when ADA is specified as currency', async () => {
+    const response = await serverWithMultiassetsSupport.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vpqwk50mnckqnjvzdd7lhln2685xep2xf84jmhd9njd5kucdqnufv', [
+        {
+          decimals: 0,
+          symbol: '4154414441636f696e',
+          metadata: {
+            policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
+          }
+        },
+        {
+          decimals: 6,
+          symbol: 'ADA'
+        }
+      ])
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual({
+      block_identifier: latestBlockIdentifierMAServer,
+      coins: [
+        {
+          coin_identifier: { identifier: '7260f6b728bf49a95095da74ca9ec88cdbfb414eea81eaeb7d1939bbe6745b12:0' },
+          amount: {
+            currency: { decimals: 6, symbol: 'ADA' },
+            value: '2000000'
+          },
+          metadata: {
+            '7260f6b728bf49a95095da74ca9ec88cdbfb414eea81eaeb7d1939bbe6745b12:0': [
+              {
+                policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd',
+                tokens: [
+                  {
+                    value: '50',
+                    currency: {
+                      symbol: '42435348',
+                      decimals: 0,
+                      metadata: { policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd' }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          coin_identifier: { identifier: 'b352ea2f50d47851bda890ba2baed955f2f9aa3667ea69136454fa2a2de11ffe:0' },
+          amount: {
+            value: '5000000',
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            }
+          },
+          metadata: {
+            'b352ea2f50d47851bda890ba2baed955f2f9aa3667ea69136454fa2a2de11ffe:0': [
+              {
+                policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518',
+                tokens: [
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '4154414441636f696e',
+                      decimals: 0,
+                      metadata: { policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518' }
+                    }
+                  },
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '61646f736961',
+                      decimals: 0,
+                      metadata: { policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518' }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd',
+                tokens: [
+                  {
+                    value: '2',
+                    currency: {
+                      symbol: '42435348',
+                      decimals: 0,
+                      metadata: { policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd' }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9',
+                tokens: [
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '676f6c64',
+                      decimals: 0,
+                      metadata: { policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9' }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          coin_identifier: { identifier: 'e58247e88790192246039816d27b58501c6686ab1f945cffec5262feedba4d23:0' },
+          amount: {
+            currency: { decimals: 6, symbol: 'ADA' },
+            value: '2000000'
+          },
+          metadata: {
+            'e58247e88790192246039816d27b58501c6686ab1f945cffec5262feedba4d23:0': [
+              {
+                policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9',
+                tokens: [
+                  {
+                    value: '5',
+                    currency: {
+                      symbol: '676f6c64',
+                      decimals: 0,
+                      metadata: { policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9' }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    });
+  });
   test('should return coins for multi asset currency with empty name', async () => {
     const response = await serverWithMultiassetsSupport.inject({
       method: 'post',
@@ -464,6 +599,7 @@ describe('/account/coins endpoint', () => {
       ]
     });
   });
+
   test('should fail when querying for a currency with non hex string symbol', async () => {
     const invalidSymbol = 'thisIsANonHexString';
     const response = await server.inject({
@@ -533,6 +669,29 @@ describe('/account/coins endpoint', () => {
       message: 'Invalid policy id',
       retriable: false,
       details: { message: 'Given policy id is wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww' }
+    });
+  });
+  test('should fail when querying for a currency with a non hex policy id', async () => {
+    const invalidPolicy = 'thisIsANonHexString';
+    const response = await server.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vre2sc6w0zftnhselly9fd6kqqnmfmklful9zcmdh92mewszqs66y', [
+        {
+          decimals: 0,
+          symbol: '486173414e616d65',
+          metadata: {
+            policyId: invalidPolicy
+          }
+        }
+      ])
+    });
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({
+      code: 4023,
+      message: 'Invalid policy id',
+      retriable: false,
+      details: { message: 'Given policy id is thisIsANonHexString' }
     });
   });
 });

--- a/cardano-rosetta-server/test/e2e/account/account-coins-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-coins-api.test.ts
@@ -1,0 +1,189 @@
+/* eslint-disable camelcase */
+/* eslint-disable no-magic-numbers */
+import { FastifyInstance } from 'fastify';
+import StatusCodes from 'http-status-codes';
+import { Pool } from 'pg';
+import { CARDANO } from '../../../src/server/utils/constants';
+import { latestBlockIdentifier, latestBlockIdentifierMAServer, address1vpfCoins } from '../fixture-data';
+import { setupDatabase, setupServer } from '../utils/test-utils';
+
+const generatePayload = (blockchain: string, network: string, address: string) => ({
+  // eslint-disable-next-line camelcase
+  network_identifier: {
+    blockchain,
+    network
+  },
+  account_identifier: { address }
+});
+
+const ACCOUNT_COINS_ENDPOINT = '/account/coins';
+
+describe('/account/coins endpoint', () => {
+  let database: Pool;
+  let server: FastifyInstance;
+  let multiassetsDatabase: Pool;
+  let serverWithMultiassetsSupport: FastifyInstance;
+  beforeAll(async () => {
+    database = setupDatabase();
+    server = setupServer(database);
+    multiassetsDatabase = setupDatabase(process.env.DB_CONNECTION_STRING, 'launchpad');
+    serverWithMultiassetsSupport = setupServer(multiassetsDatabase);
+  });
+
+  afterAll(async () => {
+    await database.end();
+    await multiassetsDatabase.end();
+  });
+
+  test('should only consider coins till latest block', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(
+        CARDANO,
+        'mainnet',
+        'DdzFFzCqrhsdufpFxByLTQmktKJnTrudktaHq1nK2MAEDLXjz5kbRcr5prHi9gHb6m8pTvhgK6JbFDZA1LTiTcP6g8KuPSF1TfKP8ewp'
+      )
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual({
+      block_identifier: latestBlockIdentifier,
+      coins: [
+        {
+          coin_identifier: {
+            identifier: '4bcf79c0c2967986749fd0ae03f5b54a712d51b35672a3d974707c060c4d8dac:1'
+          },
+          amount: { value: '10509579714', currency: { decimals: 6, symbol: 'ADA' } }
+        },
+        {
+          coin_identifier: {
+            identifier: 'bcc57134d1bd588b00f40142f0fdc17db5f35047e3196cdf26aa7319524c0014:1'
+          },
+          amount: { value: '999800000', currency: { decimals: 6, symbol: 'ADA' } }
+        }
+      ]
+    });
+  });
+
+  test('should return empty if address doesnt exist', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(CARDANO, 'mainnet', 'fakeAddress')
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({
+      code: 4015,
+      message: 'Provided address is invalid',
+      retriable: true,
+      details: { message: 'fakeAddress' }
+    });
+  });
+  test('should have no coins for an account with zero balance', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(
+        CARDANO,
+        'mainnet',
+        'DdzFFzCqrhsszHTvbjTmYje5hehGbadkT6WgWbaqCy5XNxNttsPNF13eAjjBHYT7JaLJz2XVxiucam1EvwBRPSTiCrT4TNCBas4hfzic'
+      )
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual({
+      block_identifier: latestBlockIdentifier,
+      coins: []
+    });
+  });
+  test('should return no coins for stake accounts', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(CARDANO, 'mainnet', 'stake1uyqq2a22arunrft3k9ehqc7yjpxtxjmvgndae80xw89mwyge9skyp')
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual({
+      block_identifier: latestBlockIdentifier,
+      coins: []
+    });
+  });
+
+  test('should return coins with multi assets currencies', async () => {
+    const response = await serverWithMultiassetsSupport.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc')
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json().block_identifier).toEqual(latestBlockIdentifierMAServer);
+    expect(response.json().coins).toHaveLength(address1vpfCoins.length);
+    address1vpfCoins.forEach(address1vpfCoin => expect(response.json().coins).toContainEqual(address1vpfCoin));
+  });
+
+  test('should return coins for ma with empty name', async () => {
+    const response = await serverWithMultiassetsSupport.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vre2sc6w0zftnhselly9fd6kqqnmfmklful9zcmdh92mewszqs66y')
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual({
+      block_identifier: latestBlockIdentifierMAServer,
+      coins: [
+        {
+          coin_identifier: { identifier: '95e1117558c2d075a4cd110ab0772460340f72a19ac5bc4691c6498e28055339:0' },
+          amount: {
+            currency: { decimals: 6, symbol: 'ADA' },
+            value: '4600000'
+          },
+          metadata: {
+            '95e1117558c2d075a4cd110ab0772460340f72a19ac5bc4691c6498e28055339:0': [
+              {
+                policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e',
+                tokens: [
+                  {
+                    value: '20',
+                    currency: {
+                      decimals: 0,
+                      symbol: '\\x',
+                      metadata: {
+                        policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
+                      }
+                    }
+                  },
+                  {
+                    value: '30',
+                    currency: {
+                      decimals: 0,
+                      symbol: '486173414e616d65',
+                      metadata: {
+                        policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d',
+                tokens: [
+                  {
+                    value: '10',
+                    currency: {
+                      decimals: 0,
+                      symbol: '7376c3a57274',
+                      metadata: {
+                        policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d'
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    });
+  });
+});

--- a/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-derive-api.test.ts
@@ -89,7 +89,9 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
       payload: generatePayload({ blockchain: 'cardano', network: 'mainnet' })
     });
     expect(response.statusCode).toEqual(StatusCodes.OK);
-    expect(response.json().address).toEqual('addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx');
+    expect(response.json().account_identifier.address).toEqual(
+      'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+    );
   });
 
   test('Should return an error when the public key has a lower length than 32', async () => {
@@ -198,7 +200,7 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
     // Address generated locally with following command (using private keys attached to issue #198):
     // eslint-disable-next-line max-len
     // cat addr.prv | ./cardano-address key public | ./cardano-address address payment  --network-tag 1 | ./cardano-address address delegation $(cat stake.prv | ./cardano-address key public)
-    expect(response.json().address).toEqual(
+    expect(response.json().account_identifier.address).toEqual(
       'addr1q9dhy809valxaer3nlvg2h5nudd62pxp6lu0cs36zczhfr98y6pah6lvppk8xft57nef6yexqh6rr204yemcmm3emhzsgg4fg0'
     );
   });
@@ -233,7 +235,9 @@ describe(CONSTRUCTION_DERIVE_ENDPOINT, () => {
     expect(response.statusCode).toEqual(StatusCodes.OK);
     // eslint-disable-next-line max-len
     // https://cardanoscan.io/address/015b721de5677e6ee4719fd8855e93e35ba504c1d7f8fc423a1605748ca72683dbebec086c732574f4f29d132605f431a9f526778dee39ddc5
-    expect(response.json().address).toEqual('stake1uxnjdq7ma0kqsmrny460fu5azvnqtap3486jvaudacuam3g3yc4nu');
+    expect(response.json().account_identifier.address).toEqual(
+      'stake1uxnjdq7ma0kqsmrny460fu5azvnqtap3486jvaudacuam3g3yc4nu'
+    );
   });
 
   test('Should return an error when the staking key has a lower length than 32', async () => {

--- a/cardano-rosetta-server/test/e2e/construction/construction-parse-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-parse-api.test.ts
@@ -64,7 +64,9 @@ describe(CONSTRUCTION_PARSE_ENDPOINT, () => {
     });
     expect(response.statusCode).toEqual(StatusCodes.OK);
     expect(response.json().operations).toEqual(constructionParseOperations(CONSTRUCTION_PAYLOADS_REQUEST));
-    expect(response.json().signers).toEqual([CONSTRUCTION_PAYLOADS_REQUEST.operations[0].account?.address]);
+    expect(response.json().account_identifier_signers).toEqual([
+      { address: CONSTRUCTION_PAYLOADS_REQUEST.operations[0].account?.address }
+    ]);
   });
 
   test('Should return valid data if a valid signed transaction with a Byron address is set', async () => {
@@ -82,7 +84,7 @@ describe(CONSTRUCTION_PARSE_ENDPOINT, () => {
     expect(response.json().operations).toEqual(
       constructionParseOperations(CONSTRUCTION_PAYLOADS_REQUEST_WITH_BYRON_OUTPUT)
     );
-    expect(response.json().signers).toEqual([
+    expect([response.json().account_identifier_signers[0].address]).toEqual([
       CONSTRUCTION_PAYLOADS_REQUEST_WITH_BYRON_OUTPUT.operations[0].account?.address
     ]);
   });
@@ -98,7 +100,9 @@ describe(CONSTRUCTION_PARSE_ENDPOINT, () => {
     expect(response.json().operations).toEqual(
       constructionParseOperations(CONSTRUCTION_PAYLOADS_WITH_STAKE_KEY_REGISTRATION)
     );
-    expect(response.json().signers).toEqual([
+    expect(
+      response.json().account_identifier_signers.map((account_signer: { address: any }) => account_signer.address)
+    ).toEqual([
       CONSTRUCTION_PAYLOADS_WITH_STAKE_KEY_REGISTRATION.operations[0].account?.address,
       'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5'
     ]);
@@ -120,7 +124,9 @@ describe(CONSTRUCTION_PARSE_ENDPOINT, () => {
     expect(response.json().operations).toEqual(
       constructionParseOperations(CONSTRUCTION_PAYLOADS_WITH_STAKE_KEY_REGISTRATION_AND_WITHDRAWAL)
     );
-    expect(response.json().signers).toEqual([
+    expect(
+      response.json().account_identifier_signers.map((account_signer: { address: any }) => account_signer.address)
+    ).toEqual([
       CONSTRUCTION_PAYLOADS_WITH_STAKE_KEY_REGISTRATION_AND_WITHDRAWAL.operations[0].account?.address,
       'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5'
     ]);
@@ -135,7 +141,7 @@ describe(CONSTRUCTION_PARSE_ENDPOINT, () => {
 
     expect(response.statusCode).toEqual(StatusCodes.OK);
     expect(response.json().operations).toEqual(constructionParseOperations(CONSTRUCTION_PAYLOADS_REQUEST));
-    expect(response.json().signers).toEqual([]);
+    expect(response.json().account_identifier_signers).toEqual([]);
   });
 
   // eslint-disable-next-line max-len
@@ -149,7 +155,7 @@ describe(CONSTRUCTION_PARSE_ENDPOINT, () => {
     expect(response.json().operations).toEqual(
       constructionParseOperations(CONSTRUCTION_PAYLOADS_WITH_STAKE_KEY_REGISTRATION)
     );
-    expect(response.json().signers).toEqual([]);
+    expect(response.json().account_identifier_signers).toEqual([]);
   });
 
   // eslint-disable-next-line max-len
@@ -163,7 +169,7 @@ describe(CONSTRUCTION_PARSE_ENDPOINT, () => {
     expect(response.json().operations).toEqual(
       constructionParseOperations(CONSTRUCTION_PAYLOADS_WITH_STAKE_KEY_DEREGISTRATION)
     );
-    expect(response.json().signers).toEqual([]);
+    expect(response.json().account_identifier_signers).toEqual([]);
   });
 
   // eslint-disable-next-line max-len
@@ -177,7 +183,7 @@ describe(CONSTRUCTION_PARSE_ENDPOINT, () => {
     expect(response.json().operations).toEqual(
       constructionParseOperations(CONSTRUCTION_PAYLOADS_WITH_STAKE_DELEGATION)
     );
-    expect(response.json().signers).toEqual([]);
+    expect(response.json().account_identifier_signers).toEqual([]);
   });
 
   // eslint-disable-next-line max-len
@@ -196,7 +202,7 @@ describe(CONSTRUCTION_PARSE_ENDPOINT, () => {
     expect(response.json().operations).toEqual(
       constructionParseOperations(CONSTRUCTION_PAYLOADS_WITH_STAKE_REGISTRATION_AND_DELEGATION)
     );
-    expect(response.json().signers).toEqual([]);
+    expect(response.json().account_identifier_signers).toEqual([]);
   });
 
   // eslint-disable-next-line max-len
@@ -208,7 +214,7 @@ describe(CONSTRUCTION_PARSE_ENDPOINT, () => {
     });
     expect(response.statusCode).toEqual(StatusCodes.OK);
     expect(response.json().operations).toEqual(constructionParseOperations(CONSTRUCTION_PAYLOADS_WITH_WITHDRAWAL));
-    expect(response.json().signers).toEqual([]);
+    expect(response.json().account_identifier_signers).toEqual([]);
   });
 
   // eslint-disable-next-line max-len
@@ -227,7 +233,7 @@ describe(CONSTRUCTION_PARSE_ENDPOINT, () => {
     expect(response.json().operations).toEqual(
       constructionParseOperations(CONSTRUCTION_PAYLOADS_WITH_STAKE_KEY_REGISTRATION_AND_WITHDRAWAL)
     );
-    expect(response.json().signers).toEqual([]);
+    expect(response.json().account_identifier_signers).toEqual([]);
   });
 
   test('Should throw an error when invalid signed transaction bytes are provided', async () => {

--- a/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
@@ -613,7 +613,7 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
     });
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
     expect(response.json()).toEqual({
-      code: 4021,
+      code: 4025,
       details: {
         message:
           // eslint-disable-next-line max-len

--- a/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
@@ -91,7 +91,9 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
       unsigned_transaction: CONSTRUCTION_PAYLOADS_RESPONSE,
       payloads: [
         {
-          address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx',
+          account_identifier: {
+            address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+          },
           signature_type: SIGNATURE_TYPE,
           hex_bytes: '333a6ccaaa639f7b451ce93764f54f654ef499fdb7b8b24374ee9d99eab9d795'
         }
@@ -344,7 +346,9 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
       unsigned_transaction: CONSTRUCTION_PAYLOADS_STAKE_REGISTRATION_RESPONSE,
       payloads: [
         {
-          address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx',
+          account_identifier: {
+            address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+          },
           signature_type: SIGNATURE_TYPE,
           hex_bytes: 'ec6bb1091d68dcb3e4f4889329e143fbb6090b8e78c74e7c8d0903d9eec4eed1'
         }
@@ -364,12 +368,16 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
       unsigned_transaction: CONSTRUCTION_PAYLOADS_STAKE_DELEGATION_RESPONSE,
       payloads: [
         {
-          address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx',
+          account_identifier: {
+            address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+          },
           signature_type: SIGNATURE_TYPE,
           hex_bytes: 'd4818d5a1ad1163fdb84b1e538d6d2c2fc34a86a91cd13f628dd3a7e4458a7c1'
         },
         {
-          address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5',
+          account_identifier: {
+            address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5'
+          },
           signature_type: SIGNATURE_TYPE,
           hex_bytes: 'd4818d5a1ad1163fdb84b1e538d6d2c2fc34a86a91cd13f628dd3a7e4458a7c1'
         }
@@ -389,12 +397,16 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
       unsigned_transaction: CONSTRUCTION_PAYLOADS_STAKE_REGISTRATION_AND_DELEGATION_RESPONSE,
       payloads: [
         {
-          address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx',
+          account_identifier: {
+            address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+          },
           signature_type: SIGNATURE_TYPE,
           hex_bytes: 'dbf6479409a59e3e99c79b9c46b6af714de7c8264094b1d38c373b7454acf33d'
         },
         {
-          address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5',
+          account_identifier: {
+            address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5'
+          },
           signature_type: SIGNATURE_TYPE,
           hex_bytes: 'dbf6479409a59e3e99c79b9c46b6af714de7c8264094b1d38c373b7454acf33d'
         }
@@ -414,12 +426,16 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
       unsigned_transaction: CONSTRUCTION_PAYLOADS_WITHDRAWAL_RESPONSE,
       payloads: [
         {
-          address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx',
+          account_identifier: {
+            address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+          },
           signature_type: SIGNATURE_TYPE,
           hex_bytes: 'da2eb0d62aee9313fc68df0827bd176b55168bc9129aedce92f4e29b1d52de38'
         },
         {
-          address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5',
+          account_identifier: {
+            address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5'
+          },
           signature_type: SIGNATURE_TYPE,
           hex_bytes: 'da2eb0d62aee9313fc68df0827bd176b55168bc9129aedce92f4e29b1d52de38'
         }
@@ -439,12 +455,16 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
       unsigned_transaction: CONSTRUCTION_PAYLOADS_STAKE_REGISTRATION_AND_WITHDRAWAL_RESPONSE,
       payloads: [
         {
-          address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx',
+          account_identifier: {
+            address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+          },
           signature_type: SIGNATURE_TYPE,
           hex_bytes: '8b47f0f3690167b596f1e7623e1869148f6bea78ebceaa08fe890a2e3e9e4d89'
         },
         {
-          address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5',
+          account_identifier: {
+            address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5'
+          },
           signature_type: SIGNATURE_TYPE,
           hex_bytes: '8b47f0f3690167b596f1e7623e1869148f6bea78ebceaa08fe890a2e3e9e4d89'
         }
@@ -464,12 +484,16 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
       unsigned_transaction: CONSTRUCTION_PAYLOADS_STAKE_DEREGISTRATION_RESPONSE,
       payloads: [
         {
-          address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx',
+          account_identifier: {
+            address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+          },
           signature_type: SIGNATURE_TYPE,
           hex_bytes: '9c0f4e7fa746738d3df3665fc7cd11b2e3115e3268a047e0435f2454ed41fdc5'
         },
         {
-          address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5',
+          account_identifier: {
+            address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5'
+          },
           signature_type: SIGNATURE_TYPE,
           hex_bytes: '9c0f4e7fa746738d3df3665fc7cd11b2e3115e3268a047e0435f2454ed41fdc5'
         }
@@ -612,7 +636,9 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
       unsigned_transaction: CONSTRUCTION_PAYLOADS_REQUEST_WITH_MA_RESPONSE,
       payloads: [
         {
-          address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx',
+          account_identifier: {
+            address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+          },
           hex_bytes: '3a4e241fe0c56f8001cb2e71ffdf10e2804437b4159930c32d59e3b4469203d6',
           signature_type: SIGNATURE_TYPE
         }

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/prevent-abbreviations */
 /* eslint-disable max-len */
 /* eslint-disable no-magic-numbers */
 import cbor from 'cbor';
@@ -3636,3 +3637,5 @@ export const balancesAtBlock213892 = [
     }
   }
 ];
+
+export const coinIdentifier95e1 = { identifier: '95e1117558c2d075a4cd110ab0772460340f72a19ac5bc4691c6498e28055339:0' };

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -33,7 +33,10 @@ export const latestBlockIdentifier = {
   hash: latestBlockHash,
   index: 4853177
 };
-
+export const latestBlockIdentifierMAServer = {
+  hash: '0700721626036f82476e0deb2eff43845c33823b646250fbf42fa0247149c8e0',
+  index: 382908
+};
 export const block23236WithTransactions = {
   block: {
     block_identifier: {
@@ -3594,78 +3597,6 @@ export const balancesAtBlock213891 = [
   }
 ];
 
-const coinId30d9 = { identifier: '30d97e64d1892ed7e03faf544318f167443a0153c244305df9b0f796a0386c8b:0' };
-export const coinsAtBlock213891 = [
-  {
-    coin_identifier: coinId30d9,
-    amount: {
-      value: '299994729944',
-      currency: {
-        decimals: 6,
-        symbol: 'ADA'
-      }
-    },
-    metadata: {
-      '30d97e64d1892ed7e03faf544318f167443a0153c244305df9b0f796a0386c8b:0': [
-        {
-          policyId: '06e5f0ade7121aaefa0e7ec53cac61820d774de0c12c83e8597627ff',
-          tokens: [
-            {
-              value: '10',
-              currency: {
-                decimals: 0,
-                symbol: '74657374746f6b656e',
-                metadata: {
-                  policyId: '06e5f0ade7121aaefa0e7ec53cac61820d774de0c12c83e8597627ff'
-                }
-              }
-            }
-          ]
-        },
-        {
-          policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518',
-          tokens: [
-            {
-              value: '95',
-              currency: {
-                decimals: 0,
-                symbol: '4154414441636f696e',
-                metadata: {
-                  policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
-                }
-              }
-            },
-            {
-              value: '2500',
-              currency: {
-                decimals: 0,
-                symbol: '6d616368746c636f696e',
-                metadata: {
-                  policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
-                }
-              }
-            }
-          ]
-        },
-        {
-          policyId: 'ecd07b4ef62f37a68d145de8efd60c53d288dd5ffc641215120cc3db',
-          tokens: [
-            {
-              value: '500',
-              currency: {
-                decimals: 0,
-                symbol: '6d616368746c32636f696e',
-                metadata: {
-                  policyId: 'ecd07b4ef62f37a68d145de8efd60c53d288dd5ffc641215120cc3db'
-                }
-              }
-            }
-          ]
-        }
-      ]
-    }
-  }
-];
 export const balancesAtBlock213892 = [
   {
     value: '299994547239',
@@ -3702,64 +3633,6 @@ export const balancesAtBlock213892 = [
       metadata: {
         policyId: 'ecd07b4ef62f37a68d145de8efd60c53d288dd5ffc641215120cc3db'
       }
-    }
-  }
-];
-
-const coinId1a04 = { identifier: '1a04005e5459b07a6353f5c1a9b1066d5969638b681923af6cb0601cf8c57495:0' };
-export const coinsAtBlock213892 = [
-  {
-    coin_identifier: coinId1a04,
-    amount: {
-      value: '299994547239',
-      currency: {
-        decimals: 6,
-        symbol: 'ADA'
-      }
-    },
-    metadata: {
-      '1a04005e5459b07a6353f5c1a9b1066d5969638b681923af6cb0601cf8c57495:0': [
-        {
-          policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518',
-          tokens: [
-            {
-              value: '95',
-              currency: {
-                decimals: 0,
-                symbol: '4154414441636f696e',
-                metadata: {
-                  policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
-                }
-              }
-            },
-            {
-              value: '2500',
-              currency: {
-                decimals: 0,
-                symbol: '6d616368746c636f696e',
-                metadata: {
-                  policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
-                }
-              }
-            }
-          ]
-        },
-        {
-          policyId: 'ecd07b4ef62f37a68d145de8efd60c53d288dd5ffc641215120cc3db',
-          tokens: [
-            {
-              value: '500',
-              currency: {
-                decimals: 0,
-                symbol: '6d616368746c32636f696e',
-                metadata: {
-                  policyId: 'ecd07b4ef62f37a68d145de8efd60c53d288dd5ffc641215120cc3db'
-                }
-              }
-            }
-          ]
-        }
-      ]
     }
   }
 ];

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -141,17 +141,7 @@ const allow = {
   ],
   historical_balance_lookup: true,
   call_methods: [],
-  balance_exemptions: [
-    {
-      exemption_type: 'greater_or_equal'
-    },
-    {
-      exemption_type: 'less_or_equal'
-    },
-    {
-      exemption_type: 'dynamic'
-    }
-  ],
+  balance_exemptions: [],
   mempool_coins: false
 };
 

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -96,17 +96,19 @@ const allow = {
     },
     {
       code: 4021,
-      message: 'Provided pool key hash has invalid format',
-      retriable: false
-    },
-    {
-      code: 4022,
       message: 'Assets are required for output operation token bundle',
       retriable: false
     },
     {
-      code: 4023,
+      code: 4022,
       message: 'Asset value is required for token asset',
+      retriable: false
+    },
+    { code: 4023, message: 'Invalid policy id', retriable: false },
+    { code: 4024, message: 'Invalid token name', retriable: false },
+    {
+      code: 4025,
+      message: 'Provided pool key hash has invalid format',
       retriable: false
     },
     {

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -141,7 +141,17 @@ const allow = {
   ],
   historical_balance_lookup: true,
   call_methods: [],
-  balance_exemptions: [],
+  balance_exemptions: [
+    {
+      exemption_type: 'greater_or_equal'
+    },
+    {
+      exemption_type: 'less_or_equal'
+    },
+    {
+      exemption_type: 'dynamic'
+    }
+  ],
   mempool_coins: false
 };
 

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -137,11 +137,14 @@ const allow = {
       retriable: true
     }
   ],
-  historical_balance_lookup: true
+  historical_balance_lookup: true,
+  call_methods: [],
+  balance_exemptions: [],
+  mempool_coins: false
 };
 
 const version = {
-  rosetta_version: '1.4.4',
+  rosetta_version: '1.4.10',
   node_version: 'cardano-node 1.18.0 - linux-x86_64 - ghc-8.6\ngit rev 36ad7b90bfbde8afd41b68ed9b928df3fcab0dbc',
   middleware_version: packageJson.version,
   metadata: {}

--- a/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
@@ -1,5 +1,5 @@
 import { mapToAccountBalanceResponse } from '../../../src/server/utils/data-mapper';
-import { BlockUtxos } from '../../../src/server/models';
+import { BlockUtxosMultiAssets } from '../../../src/server/models';
 
 describe('Data Mapper', () => {
   describe('mapToAccountBalanceResponse', () => {
@@ -8,7 +8,7 @@ describe('Data Mapper', () => {
     // addr_test1vrd26p8d9dlknc4fhevzudcfzuul5qm2znquytugqcw583czzqrpm at
     // 1630464 (computed: 37999999978288983ADA, live: 37999999978288984ADA)"
     it('Should properly process BigInt balances', () => {
-      const blockUtxos: BlockUtxos = {
+      const blockUtxos: BlockUtxosMultiAssets = {
         block: {
           hash: '032349b3b569bc1ecb266b79ae28a5e79834377562a627f0dc99fa3cd1bfd546',
           number: 1627535,

--- a/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
@@ -46,21 +46,6 @@ describe('Data Mapper', () => {
           hash: '032349b3b569bc1ecb266b79ae28a5e79834377562a627f0dc99fa3cd1bfd546',
           index: 1627535
         }
-        // coins: [
-        //   {
-        //     amount: {
-        //       currency: {
-        //         decimals: 6,
-        //         symbol: 'ADA'
-        //       },
-        //       value: '37999999989620601'
-        //     },
-        //     // eslint-disable-next-line camelcase
-        //     coin_identifier: {
-        //       identifier: 'c09c523b0a94837dacf08e30f8cc6d5915786b883f822981ea2012551f8699ce:1'
-        //     }
-        //   }
-        // ]
       });
     });
   });

--- a/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
@@ -25,10 +25,7 @@ describe('Data Mapper', () => {
           {
             value: '37999999989620601',
             transactionHash: 'c09c523b0a94837dacf08e30f8cc6d5915786b883f822981ea2012551f8699ce',
-            index: 1,
-            quantity: '',
-            name: '',
-            policy: ''
+            index: 1
           }
         ],
         maBalances: []
@@ -48,22 +45,22 @@ describe('Data Mapper', () => {
         block_identifier: {
           hash: '032349b3b569bc1ecb266b79ae28a5e79834377562a627f0dc99fa3cd1bfd546',
           index: 1627535
-        },
-        coins: [
-          {
-            amount: {
-              currency: {
-                decimals: 6,
-                symbol: 'ADA'
-              },
-              value: '37999999989620601'
-            },
-            // eslint-disable-next-line camelcase
-            coin_identifier: {
-              identifier: 'c09c523b0a94837dacf08e30f8cc6d5915786b883f822981ea2012551f8699ce:1'
-            }
-          }
-        ]
+        }
+        // coins: [
+        //   {
+        //     amount: {
+        //       currency: {
+        //         decimals: 6,
+        //         symbol: 'ADA'
+        //       },
+        //       value: '37999999989620601'
+        //     },
+        //     // eslint-disable-next-line camelcase
+        //     coin_identifier: {
+        //       identifier: 'c09c523b0a94837dacf08e30f8cc6d5915786b883f822981ea2012551f8699ce:1'
+        //     }
+        //   }
+        // ]
       });
     });
   });


### PR DESCRIPTION
# Description

Updates api to 1.4.10

# Important Changes Introduced

- updates `openApi.json` according to Rosetta 1.4.10
- `/account/coins` endpoint added
- `/account/balance` adapted
- deprecate address based fields at `ConstructionDeriveResponse`, `ConstructionParseResponse` and `SigningPayload`
- Support Account Balance Tracking "Exemptions"
- Update network options response (adds  `historical_balance_lookup` and `mempool_coins` fields at NetworkOptionsResponse.Allow)

# Testing

Running the test suits should be enough. Old tests were adapted and new ones were created for `/account/coins`.

# References

Closes #335.
