### PR TITLE
Feat/create account coins endpoint

### DIFF
--- a/cardano-rosetta-server/src/server/controllers/account-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/account-controller.ts
@@ -60,12 +60,12 @@ const configure = (
           throw ErrorFactory.invalidAddressError(accountAddress);
         currencies?.forEach(({ symbol, metadata }) => {
           if (!isTokenNameValid(symbol)) throw ErrorFactory.invalidTokenNameError(`Given name is ${symbol}`);
-          if (!isPolicyIdValid(metadata.policyId))
+          if (symbol !== ADA && !isPolicyIdValid(metadata.policyId))
             throw ErrorFactory.invalidPolicyIdError(`Given policy id is ${metadata.policyId}`);
         });
-        // if ADA is requested as currency then all coins will be returned
+        // if ADA is requested then all coins will be returned
         const currenciesRequested =
-          currencies && !currencies.map(currency => currency.symbol).includes(ADA) ? currencies : [];
+          currencies && !currencies.map(currency => currency.symbol).some(s => s === ADA) ? currencies : [];
         const blockUtxos = await blockService.findCoinsDataByAddress(logger, accountAddress, currenciesRequested);
         const toReturn = mapToAccountCoinsResponse(blockUtxos);
         logger.debug(toReturn, '[accountCoins] About to return ');

--- a/cardano-rosetta-server/src/server/controllers/account-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/account-controller.ts
@@ -56,7 +56,6 @@ const configure = (
         logger.debug({ accountBalanceRequest: request.body }, '[accountCoins] Request received');
         if (cardanoService.getEraAddressType(accountAddress) === null)
           throw ErrorFactory.invalidAddressError(accountAddress);
-        logger.info('[accountCoins] Looking for latest block');
         const blockUtxos = await blockService.findCoinsDataByAddress(logger, accountAddress);
         const toReturn = mapToAccountCoinsResponse(blockUtxos);
         logger.debug(toReturn, '[accountCoins] About to return ');

--- a/cardano-rosetta-server/src/server/controllers/account-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/account-controller.ts
@@ -3,13 +3,16 @@ import { withNetworkValidation } from '../controllers/controllers-helper';
 import { BlockService } from '../services/block-service';
 import { CardanoService } from '../services/cardano-services';
 import { NetworkService } from '../services/network-service';
-import { mapToAccountBalanceResponse } from '../utils/data-mapper';
+import { mapToAccountBalanceResponse, mapToAccountCoinsResponse } from '../utils/data-mapper';
 import { ErrorFactory } from '../utils/errors';
 
 export interface AccountController {
   accountBalance(
     request: FastifyRequest<unknown, unknown, unknown, unknown, Components.Schemas.AccountBalanceRequest>
   ): Promise<Components.Schemas.AccountBalanceResponse | Components.Schemas.Error>;
+  accountCoins(
+    request: FastifyRequest<unknown, unknown, unknown, unknown, Components.Schemas.AccountCoinsRequest>
+  ): Promise<Components.Schemas.AccountCoinsResponse | Components.Schemas.Error>;
 }
 
 const configure = (
@@ -37,6 +40,26 @@ const configure = (
         );
         const toReturn = mapToAccountBalanceResponse(blockBalanceData);
         logger.debug(toReturn, '[accountBalance] About to return ');
+        return toReturn;
+      },
+      request.log,
+      networkService
+    ),
+  accountCoins: async request =>
+    withNetworkValidation(
+      request.body.network_identifier,
+      request,
+      async () => {
+        const logger = request.log;
+        const accountCoinsRequest = request.body;
+        const accountAddress = accountCoinsRequest.account_identifier.address;
+        logger.debug({ accountBalanceRequest: request.body }, '[accountCoins] Request received');
+        if (cardanoService.getEraAddressType(accountAddress) === null)
+          throw ErrorFactory.invalidAddressError(accountAddress);
+        logger.info('[accountCoins] Looking for latest block');
+        const blockUtxos = await blockService.findCoinsDataByAddress(logger, accountAddress);
+        const toReturn = mapToAccountCoinsResponse(blockUtxos);
+        logger.debug(toReturn, '[accountCoins] About to return ');
         return toReturn;
       },
       request.log,

--- a/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
+++ b/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
@@ -247,7 +247,7 @@ LEFT JOIN tx_in ON
   tx_out.index::smallint = tx_in.tx_out_index::smallint 
 LEFT JOIN tx as tx_in_tx ON 
   tx_in_tx.id = tx_in.tx_in_id AND
-  tx_in_tx.block_id <= (select id from block where hash = $2) 
+  tx_in_tx.block_id <= (select id from block where hash = $2)
 JOIN tx AS tx_out_tx ON
   tx_out_tx.id = tx_out.tx_id AND
   tx_out_tx.block_id <= (select id from block where hash = $2)
@@ -283,21 +283,22 @@ SELECT
     ma_tx_out.policy, ma_tx_out.name
   `;
 
-const findBalanceByAddressAndBlock = `SELECT (SELECT COALESCE(SUM(r.amount),0) 
-  FROM reward r
-  JOIN stake_address ON 
-    stake_address.id = r.addr_id
-  JOIN block ON
-    block.id = r.block_id
-  WHERE stake_address.view = $1
-  AND block.id <= (SELECT id FROM block WHERE hash = $2))- 
-  (SELECT COALESCE(SUM(w.amount),0) 
-  FROM withdrawal w
-  JOIN tx ON tx.id = w.tx_id AND 
-    tx.block_id <= (SELECT id FROM block WHERE hash = $2)
-  JOIN stake_address ON stake_address.id = w.addr_id
-  WHERE stake_address.view = $1) 
-  AS balance
+const findBalanceByAddressAndBlock = `
+  SELECT (SELECT COALESCE(SUM(r.amount),0) 
+      FROM reward r
+    JOIN stake_address ON 
+        stake_address.id = r.addr_id
+    JOIN block ON
+        block.id = r.block_id
+    WHERE stake_address.view = $1
+    AND block.id <= (SELECT id FROM block WHERE hash = $2))- 
+    (SELECT COALESCE(SUM(w.amount),0) 
+    FROM withdrawal w
+    JOIN tx ON tx.id = w.tx_id AND 
+      tx.block_id <= (SELECT id FROM block WHERE hash = $2)
+    JOIN stake_address ON stake_address.id = w.addr_id
+    WHERE stake_address.view = $1) 
+    AS balance
 `;
 
 const Queries = {

--- a/cardano-rosetta-server/src/server/models.ts
+++ b/cardano-rosetta-server/src/server/models.ts
@@ -114,6 +114,9 @@ export interface Network {
 export interface BlockUtxos {
   block: Block;
   utxos: Utxo[];
+}
+
+export interface BlockUtxosMultiAssets extends BlockUtxos {
   maBalances: MaBalance[];
 }
 

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1583,7 +1583,7 @@
       "AccountCoinsRequest": {
         "description": "AccountCoinsRequest is utilized to make a request on the /account/coins endpoint.",
         "type": "object",
-        "required": ["network_identifier", "account_identifier", "include_mempool"],
+        "required": ["network_identifier", "account_identifier"],
         "properties": {
           "network_identifier": {
             "$ref": "#/components/schemas/NetworkIdentifier"

--- a/cardano-rosetta-server/src/server/services/block-service.ts
+++ b/cardano-rosetta-server/src/server/services/block-service.ts
@@ -90,7 +90,11 @@ export interface BlockService {
    * @param logger
    * @param address
    */
-  findCoinsDataByAddress(logger: Logger, address: string): Promise<BlockUtxos>;
+  findCoinsDataByAddress(
+    logger: Logger,
+    address: string,
+    currencies?: Components.Schemas.Currency[]
+  ): Promise<BlockUtxos>;
 }
 
 const configure = (repository: BlockchainRepository, cardanoService: CardanoService): BlockService => ({
@@ -187,14 +191,17 @@ const configure = (repository: BlockchainRepository, cardanoService: CardanoServ
       maBalances
     };
   },
-  async findCoinsDataByAddress(logger, address) {
+  async findCoinsDataByAddress(logger, address, currencies) {
     const block = await this.findBlock(logger);
     if (block === null) {
       logger.error('[findCoinsDataByAddress] Block not found');
       throw ErrorFactory.blockNotFoundError();
     }
-    logger.info(`[findCoinsDataByAddress] Looking for utxos for address ${address}`);
-    const utxoDetails = await repository.findUtxoByAddressAndBlock(logger, address, block.hash);
+    logger.info(
+      `[findCoinsDataByAddress] Looking for utxos for address ${address} and ${currencies?.length ||
+        '0'} specified currencies`
+    );
+    const utxoDetails = await repository.findUtxoByAddressAndBlock(logger, address, block.hash, currencies);
     logger.debug(utxoDetails, `[findCoinsByAddress] Found ${utxoDetails.length} coin details for address ${address}`);
     return {
       block,

--- a/cardano-rosetta-server/src/server/services/block-service.ts
+++ b/cardano-rosetta-server/src/server/services/block-service.ts
@@ -93,7 +93,7 @@ export interface BlockService {
   findCoinsDataByAddress(
     logger: Logger,
     address: string,
-    currencies?: Components.Schemas.Currency[]
+    currencies: Components.Schemas.Currency[]
   ): Promise<BlockUtxos>;
 }
 
@@ -198,8 +198,7 @@ const configure = (repository: BlockchainRepository, cardanoService: CardanoServ
       throw ErrorFactory.blockNotFoundError();
     }
     logger.info(
-      `[findCoinsDataByAddress] Looking for utxos for address ${address} and ${currencies?.length ||
-        '0'} specified currencies`
+      `[findCoinsDataByAddress] Looking for utxos for address ${address} and ${currencies.length} specified currencies`
     );
     const utxoDetails = await repository.findUtxoByAddressAndBlock(logger, address, block.hash, currencies);
     logger.debug(utxoDetails, `[findCoinsByAddress] Found ${utxoDetails.length} coin details for address ${address}`);

--- a/cardano-rosetta-server/src/server/utils/data-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/data-mapper.ts
@@ -471,3 +471,7 @@ export const constructPayloadsForTransactionBody = (
     hex_bytes: transactionBodyHash,
     signature_type: SIGNATURE_TYPE
   }));
+
+// if ADA is requested then all coins will be returned
+export const filterRequestedCurrencies = (currencies?: Components.Schemas.Currency[]): Components.Schemas.Currency[] =>
+  currencies && !currencies.map(currency => currency.symbol).some(s => s === ADA) ? currencies : [];

--- a/cardano-rosetta-server/src/server/utils/data-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/data-mapper.ts
@@ -1,7 +1,16 @@
 /* eslint-disable camelcase */
 
 import cbor from 'cbor';
-import { BalanceAtBlock, Block, BlockUtxos, Network, PopulatedTransaction, TokenBundle, Utxo } from '../models';
+import {
+  BalanceAtBlock,
+  Block,
+  BlockUtxos,
+  BlockUtxosMultiAssets,
+  Network,
+  PopulatedTransaction,
+  TokenBundle,
+  Utxo
+} from '../models';
 import { NetworkStatus } from '../services/network-service';
 import {
   ADA,
@@ -290,42 +299,34 @@ const updateMetadataCoin = (
   return updatedCoin;
 };
 
-const mapToAddressBalanceAndCoins = (
-  blockBalanceData: BlockUtxos
-): { adaBalance: Components.Schemas.Amount; adaCoins: Map<string, Components.Schemas.Coin> } => {
-  const mappedUtxos = blockBalanceData.utxos.reduce(
-    ({ adaBalance, adaCoins }, current, index) => {
-      const previousValue = blockBalanceData.utxos[index - 1];
-      // This function accumulates ADA value. As there might be several, one for each multi-asset, we need to
-      // avoid counting them twice
-      const coinId = `${current.transactionHash}:${current.index}`;
-      if (!previousValue || !areEqualUtxos(previousValue, current)) {
-        adaBalance += BigInt(current.value);
-        adaCoins.set(coinId, {
-          coin_identifier: {
-            identifier: coinId
-          },
-          amount: mapAmount(current.value)
-        });
-      }
-      if (current.policy && current.name !== undefined && current.quantity) {
-        // MultiAsset
-        const relatedCoin = adaCoins.get(coinId);
-        if (relatedCoin) {
-          const updatedCoin = updateMetadataCoin(relatedCoin, current.policy, current.quantity, current.name);
-          adaCoins.set(coinId, updatedCoin);
-        }
-      }
-      return { adaBalance, adaCoins };
-    },
-    {
-      adaBalance: BigInt(0),
-      adaCoins: new Map<string, Components.Schemas.Coin>()
+export const mapToAccountCoinsResponse = (blockCoinsData: BlockUtxos): Components.Schemas.AccountCoinsResponse => {
+  const mappedUtxos = blockCoinsData.utxos.reduce((adaCoins, current, index) => {
+    const previousValue = blockCoinsData.utxos[index - 1];
+    const coinId = `${current.transactionHash}:${current.index}`;
+    if (!previousValue || !areEqualUtxos(previousValue, current)) {
+      adaCoins.set(coinId, {
+        coin_identifier: {
+          identifier: coinId
+        },
+        amount: mapAmount(current.value)
+      });
     }
-  );
+    if (current.policy && current.name !== undefined && current.quantity) {
+      // MultiAsset
+      const relatedCoin = adaCoins.get(coinId);
+      if (relatedCoin) {
+        const updatedCoin = updateMetadataCoin(relatedCoin, current.policy, current.quantity, current.name);
+        adaCoins.set(coinId, updatedCoin);
+      }
+    }
+    return adaCoins;
+  }, new Map<string, Components.Schemas.Coin>());
   return {
-    adaBalance: mapAmount(mappedUtxos.adaBalance.toString()),
-    adaCoins: mappedUtxos.adaCoins
+    block_identifier: {
+      index: blockCoinsData.block.number,
+      hash: blockCoinsData.block.hash
+    },
+    coins: [...mappedUtxos.values()]
   };
 };
 
@@ -335,7 +336,7 @@ const mapToAddressBalanceAndCoins = (
  * @param accountAddress
  */
 export const mapToAccountBalanceResponse = (
-  blockBalanceData: BlockUtxos | BalanceAtBlock
+  blockBalanceData: BlockUtxosMultiAssets | BalanceAtBlock
 ): Components.Schemas.AccountBalanceResponse => {
   if (isBlockUtxos(blockBalanceData)) {
     const maBalances =
@@ -344,15 +345,22 @@ export const mapToAccountBalanceResponse = (
             mapAmount(maBalance.value, maBalance.name, MULTI_ASSET_DECIMALS, { policyId: maBalance.policy })
           )
         : [];
-    const { adaBalance, adaCoins } = mapToAddressBalanceAndCoins(blockBalanceData);
-    const totalBalance = [adaBalance, ...maBalances];
+    const adaBalance = blockBalanceData.utxos.reduce((totalAmount, current, index) => {
+      const previousValue = blockBalanceData.utxos[index - 1];
+      // This function accumulates ADA value. As there might be several, one for each multi-asset, we need to
+      // avoid counting them twice
+      if (!previousValue || !areEqualUtxos(previousValue, current)) {
+        totalAmount += BigInt(current.value);
+      }
+      return totalAmount;
+    }, BigInt(0));
+    const totalBalance = [mapAmount(adaBalance.toString()), ...maBalances];
     return {
       block_identifier: {
         index: blockBalanceData.block.number,
         hash: blockBalanceData.block.hash
       },
       balances: totalBalance.length === 0 ? [mapAmount('0')] : totalBalance
-      // coins: [...adaCoins.values()]
     };
   }
   return {

--- a/cardano-rosetta-server/src/server/utils/errors.ts
+++ b/cardano-rosetta-server/src/server/utils/errors.ts
@@ -69,6 +69,8 @@ export const Errors = {
   POOL_KEY_MISSING: { message: 'Pool key hash is required for stake delegation', code: 4020 },
   TOKEN_BUNDLE_ASSETS_MISSING: { message: 'Assets are required for output operation token bundle', code: 4021 },
   TOKEN_ASSET_VALUE_MISSING: { message: 'Asset value is required for token asset', code: 4022 },
+  INVALID_POLICY_ID: { message: 'Invalid policy id', code: 4023 },
+  INVALID_TOKEN_NAME: { message: 'Invalid token name', code: 4024 },
   UNSPECIFIED_ERROR: { message: 'An error occurred', code: 5000 },
   NOT_IMPLEMENTED: { message: 'Not implemented', code: 5001 },
   ADDRESS_GENERATION_ERROR: { message: 'Address generation error', code: 5002 },
@@ -125,6 +127,10 @@ const transactionOutputDeserializationError: CreateErrorFunction = (details?: st
 const invalidAddressError: CreateErrorFunction = address => buildApiError(Errors.INVALID_ADDRESS, true, address);
 const invalidAddressTypeError: CreateErrorFunction = type => buildApiError(Errors.INVALID_ADDRESS_TYPE, true, type);
 const invalidOperationTypeError: CreateErrorFunction = type => buildApiError(Errors.INVALID_OPERATION_TYPE, true, type);
+const invalidPolicyIdError: CreateErrorFunction = (details?: string) =>
+  buildApiError(Errors.INVALID_POLICY_ID, false, details);
+const invalidTokenNameError: CreateErrorFunction = (details?: string) =>
+  buildApiError(Errors.INVALID_TOKEN_NAME, false, details);
 const tokenBundleAssetsMissingError: CreateErrorFunction = type =>
   buildApiError(Errors.TOKEN_BUNDLE_ASSETS_MISSING, false, type);
 const tokenAssetValueMissingError: CreateErrorFunction = type =>
@@ -155,6 +161,8 @@ export const ErrorFactory = {
   sendTransactionError,
   transactionInputDeserializationError,
   transactionOutputDeserializationError,
+  invalidPolicyIdError,
+  invalidTokenNameError,
   invalidAddressError,
   invalidAddressTypeError,
   invalidOperationTypeError,

--- a/cardano-rosetta-server/src/server/utils/validations.ts
+++ b/cardano-rosetta-server/src/server/utils/validations.ts
@@ -1,4 +1,5 @@
-import { PUBLIC_KEY_BYTES_LENGTH, AddressType, CurveType, ASSET_NAME_LENGTH, POLICY_ID_LENGTH } from './constants';
+import { PUBLIC_KEY_BYTES_LENGTH, ADA, AddressType, CurveType, ASSET_NAME_LENGTH, POLICY_ID_LENGTH } from './constants';
+import { ErrorFactory } from './errors';
 import { isEmptyHexString } from './formatters';
 
 const tokenNameValidation = new RegExp(`^[0-9a-fA-F]{0,${ASSET_NAME_LENGTH}}$`);
@@ -16,3 +17,11 @@ export const isAddressTypeValid = (type: string): boolean =>
 export const isTokenNameValid = (name: string): boolean => tokenNameValidation.test(name) || isEmptyHexString(name);
 
 export const isPolicyIdValid = (policyId: string): boolean => policyIdValidation.test(policyId);
+
+export const validateCurrencies = (currencies: Components.Schemas.Currency[]): void => {
+  currencies.forEach(({ symbol, metadata }) => {
+    if (!isTokenNameValid(symbol)) throw ErrorFactory.invalidTokenNameError(`Given name is ${symbol}`);
+    if (symbol !== ADA && !isPolicyIdValid(metadata.policyId))
+      throw ErrorFactory.invalidPolicyIdError(`Given policy id is ${metadata.policyId}`);
+  });
+};

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -39,7 +39,7 @@ declare namespace Components {
       /**
        * Include state from the mempool when looking up an account's unspent coins. Note, using this functionality breaks any guarantee of idempotency.
        */
-      include_mempool: boolean;
+      include_mempool?: boolean;
       /**
        * In some cases, the caller may not want to retrieve coins for all currencies for an AccountIdentifier. If the currencies field is populated, only coins for the specified currencies will be returned. If not populated, all unspent coins will be returned.
        */

--- a/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
@@ -443,49 +443,6 @@ describe('/account/balance endpoint', () => {
           }
         }
       ]
-      // coins: [
-      //   {
-      //     coin_identifier: { identifier: '02562c123f6d560e1250f5a46f7e95911b21fd8a9fa70157335c3a3d1d16bdda:0' },
-      //     amount: {
-      //       currency: { decimals: 6, symbol: 'ADA' },
-      //       value: '4800000'
-      //     },
-      //     metadata: {
-      //       '02562c123f6d560e1250f5a46f7e95911b21fd8a9fa70157335c3a3d1d16bdda:0': [
-      //         {
-      //           policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e',
-      //           tokens: [
-      //             {
-      //               value: '20',
-      //               currency: {
-      //                 decimals: 0,
-      //                 symbol: '\\x',
-      //                 metadata: {
-      //                   policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
-      //                 }
-      //               }
-      //             }
-      //           ]
-      //         },
-      //         {
-      //           policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d',
-      //           tokens: [
-      //             {
-      //               value: '10',
-      //               currency: {
-      //                 decimals: 0,
-      //                 symbol: '7376c3a57274',
-      //                 metadata: {
-      //                   policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d'
-      //                 }
-      //               }
-      //             }
-      //           ]
-      //         }
-      //       ]
-      //     }
-      //   }
-      // ]
     });
   });
 });

--- a/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
@@ -7,11 +7,8 @@ import { CARDANO } from '../../../src/server/utils/constants';
 import {
   latestBlockIdentifier,
   address1vpfAccountBalances,
-  address1vpfCoins,
   balancesAtBlock213891,
-  balancesAtBlock213892,
-  coinsAtBlock213891,
-  coinsAtBlock213892
+  balancesAtBlock213892
 } from '../fixture-data';
 import { setupDatabase, setupServer } from '../utils/test-utils';
 
@@ -38,13 +35,6 @@ const AE2HashAccountBalances = [
       symbol: 'ADA'
     },
     value: '1153846000000'
-  }
-];
-
-const AE2HashAccountUtxos = [
-  {
-    coin_identifier: { identifier: '2d51b929d79a0ac8f360f38e8a38cdcb28ca84139aced314c5d7edc739aa4366:0' },
-    amount: { value: '1153846000000', currency: { symbol: 'ADA', decimals: 6 } }
   }
 ];
 
@@ -81,12 +71,6 @@ describe('/account/balance endpoint', () => {
     expect(response.json()).toEqual({
       balances: [{ currency: { decimals: 6, symbol: 'ADA' }, value: '21063' }],
       block_identifier: latestBlockIdentifier
-      // coins: [
-      //   {
-      //     coin_identifier: { identifier: 'af0dd90debb1fbaf3854b90686ba2d6f7c95416080e8cda18d9ea3cb6bb195ad:0' },
-      //     amount: { value: '21063', currency: { symbol: 'ADA', decimals: 6 } }
-      //   }
-      // ]
     });
   });
 
@@ -103,7 +87,6 @@ describe('/account/balance endpoint', () => {
         hash: '7c6901c6346781c2bc5cbc49577490e336c2545c320ce4a61605bc71a9c5bed0',
         index: 20
       }
-      // coins: AE2HashAccountUtxos
     });
   });
 
@@ -126,7 +109,6 @@ describe('/account/balance endpoint', () => {
         hash: '7c6901c6346781c2bc5cbc49577490e336c2545c320ce4a61605bc71a9c5bed0',
         index: 20
       }
-      // coins: AE2HashAccountUtxos
     });
   });
 
@@ -149,7 +131,6 @@ describe('/account/balance endpoint', () => {
         hash: 'd3fdc8c8ea4050cc87a21cb73110d54e3ec92f8ae76941e8a1957ed6e6a7e0b0',
         index: 30
       }
-      // coins: AE2HashAccountUtxos
     });
   });
 
@@ -191,20 +172,6 @@ describe('/account/balance endpoint', () => {
           }
         }
       ]
-      // coins: [
-      //   {
-      //     coin_identifier: {
-      //       identifier: '4bcf79c0c2967986749fd0ae03f5b54a712d51b35672a3d974707c060c4d8dac:1'
-      //     },
-      //     amount: { value: '10509579714', currency: { decimals: 6, symbol: 'ADA' } }
-      //   },
-      //   {
-      //     coin_identifier: {
-      //       identifier: 'bcc57134d1bd588b00f40142f0fdc17db5f35047e3196cdf26aa7319524c0014:1'
-      //     },
-      //     amount: { value: '999800000', currency: { decimals: 6, symbol: 'ADA' } }
-      //   }
-      // ]
     });
   });
 
@@ -251,12 +218,6 @@ describe('/account/balance endpoint', () => {
           }
         }
       ]
-      // coins: [
-      //   {
-      //     amount: { value: '1000000', currency: { symbol: 'ADA', decimals: 6 } },
-      //     coin_identifier: { identifier: '6497b33b10fa2619c6efbd9f874ecd1c91badb10bf70850732aab45b90524d9e:0' }
-      //   }
-      // ]
     });
   });
   test('should only consider balance till last block and balance SHOULD be 0', async () => {
@@ -285,7 +246,6 @@ describe('/account/balance endpoint', () => {
           }
         }
       ]
-      // coins: []
     });
   });
   test('should return 0 for the balance of stake account at block with no earned rewards', async () => {
@@ -392,8 +352,6 @@ describe('/account/balance endpoint', () => {
     address1vpfAccountBalances.forEach(accountBalance =>
       expect(response.json().balances).toContainEqual(accountBalance)
     );
-    // expect(response.json().coins).toHaveLength(address1vpfCoins.length);
-    // address1vpfCoins.forEach(address1vpfCoin => expect(response.json().coins).toContainEqual(address1vpfCoin));
   });
 
   // eslint-disable-next-line max-len
@@ -441,8 +399,6 @@ describe('/account/balance endpoint', () => {
     balancesAtBlock213892.forEach(accountBalance =>
       expect(responseAtBlock213892.json().balances).toContainEqual(accountBalance)
     );
-    // expect(responseAtBlock213892.json().coins).toHaveLength(coinsAtBlock213892.length);
-    // coinsAtBlock213892.forEach(coin => expect(responseAtBlock213892.json().coins).toContainEqual(coin));
   });
 
   test('should return balances for ma with empty name', async () => {

--- a/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
@@ -389,8 +389,6 @@ describe('/account/balance endpoint', () => {
     balancesAtBlock213891.forEach(accountBalance =>
       expect(responseAtBlock213891.json().balances).toContainEqual(accountBalance)
     );
-    // expect(responseAtBlock213891.json().coins).toHaveLength(coinsAtBlock213891.length);
-    // coinsAtBlock213891.forEach(coin => expect(responseAtBlock213891.json().coins).toContainEqual(coin));
     expect(responseAtBlock213892.statusCode).toEqual(StatusCodes.OK);
     expect(responseAtBlock213892.json().block_identifier).toEqual({
       index: 213892,

--- a/cardano-rosetta-server/test/e2e/account/account-coins-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-coins-api.test.ts
@@ -201,12 +201,12 @@ describe('/account/coins endpoint', () => {
     const response = await serverWithMultiassetsSupport.inject({
       method: 'post',
       url: ACCOUNT_COINS_ENDPOINT,
-      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vre2sc6w0zftnhselly9fd6kqqnmfmklful9zcmdh92mewszqs66y', [
+      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vpqwk50mnckqnjvzdd7lhln2685xep2xf84jmhd9njd5kucdqnufv', [
         {
           decimals: 0,
-          symbol: '486173414e616d65',
+          symbol: '4154414441636f696e',
           metadata: {
-            policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
+            policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
           }
         }
       ])
@@ -216,24 +216,59 @@ describe('/account/coins endpoint', () => {
       block_identifier: latestBlockIdentifierMAServer,
       coins: [
         {
-          coin_identifier: coinIdentifier95e1,
+          coin_identifier: { identifier: 'b352ea2f50d47851bda890ba2baed955f2f9aa3667ea69136454fa2a2de11ffe:0' },
           amount: {
-            currency: { decimals: 6, symbol: 'ADA' },
-            value: '4600000'
+            value: '5000000',
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            }
           },
           metadata: {
-            '95e1117558c2d075a4cd110ab0772460340f72a19ac5bc4691c6498e28055339:0': [
+            'b352ea2f50d47851bda890ba2baed955f2f9aa3667ea69136454fa2a2de11ffe:0': [
               {
-                policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e',
+                policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518',
                 tokens: [
                   {
-                    value: '30',
+                    value: '1',
                     currency: {
+                      symbol: '4154414441636f696e',
                       decimals: 0,
-                      symbol: '486173414e616d65',
-                      metadata: {
-                        policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
-                      }
+                      metadata: { policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518' }
+                    }
+                  },
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '61646f736961',
+                      decimals: 0,
+                      metadata: { policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518' }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd',
+                tokens: [
+                  {
+                    value: '2',
+                    currency: {
+                      symbol: '42435348',
+                      decimals: 0,
+                      metadata: { policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd' }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9',
+                tokens: [
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '676f6c64',
+                      decimals: 0,
+                      metadata: { policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9' }
                     }
                   }
                 ]
@@ -248,19 +283,19 @@ describe('/account/coins endpoint', () => {
     const response = await serverWithMultiassetsSupport.inject({
       method: 'post',
       url: ACCOUNT_COINS_ENDPOINT,
-      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vre2sc6w0zftnhselly9fd6kqqnmfmklful9zcmdh92mewszqs66y', [
+      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vpqwk50mnckqnjvzdd7lhln2685xep2xf84jmhd9njd5kucdqnufv', [
         {
           decimals: 0,
-          symbol: '486173414e616d65',
+          symbol: '4154414441636f696e',
           metadata: {
-            policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
+            policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
           }
         },
         {
           decimals: 0,
-          symbol: '7376c3a57274',
+          symbol: '676f6c64',
           metadata: {
-            policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d'
+            policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9'
           }
         }
       ])
@@ -270,39 +305,83 @@ describe('/account/coins endpoint', () => {
       block_identifier: latestBlockIdentifierMAServer,
       coins: [
         {
-          coin_identifier: coinIdentifier95e1,
+          coin_identifier: { identifier: 'b352ea2f50d47851bda890ba2baed955f2f9aa3667ea69136454fa2a2de11ffe:0' },
           amount: {
-            currency: { decimals: 6, symbol: 'ADA' },
-            value: '4600000'
+            value: '5000000',
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            }
           },
           metadata: {
-            '95e1117558c2d075a4cd110ab0772460340f72a19ac5bc4691c6498e28055339:0': [
+            'b352ea2f50d47851bda890ba2baed955f2f9aa3667ea69136454fa2a2de11ffe:0': [
               {
-                policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e',
+                policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518',
                 tokens: [
                   {
-                    value: '30',
+                    value: '1',
                     currency: {
+                      symbol: '4154414441636f696e',
                       decimals: 0,
-                      symbol: '486173414e616d65',
-                      metadata: {
-                        policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
-                      }
+                      metadata: { policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518' }
+                    }
+                  },
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '61646f736961',
+                      decimals: 0,
+                      metadata: { policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518' }
                     }
                   }
                 ]
               },
               {
-                policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d',
+                policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd',
                 tokens: [
                   {
-                    value: '10',
+                    value: '2',
                     currency: {
+                      symbol: '42435348',
                       decimals: 0,
-                      symbol: '7376c3a57274',
-                      metadata: {
-                        policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d'
-                      }
+                      metadata: { policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd' }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9',
+                tokens: [
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '676f6c64',
+                      decimals: 0,
+                      metadata: { policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9' }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          coin_identifier: { identifier: 'e58247e88790192246039816d27b58501c6686ab1f945cffec5262feedba4d23:0' },
+          amount: {
+            currency: { decimals: 6, symbol: 'ADA' },
+            value: '2000000'
+          },
+          metadata: {
+            'e58247e88790192246039816d27b58501c6686ab1f945cffec5262feedba4d23:0': [
+              {
+                policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9',
+                tokens: [
+                  {
+                    value: '5',
+                    currency: {
+                      symbol: '676f6c64',
+                      decimals: 0,
+                      metadata: { policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9' }
                     }
                   }
                 ]
@@ -349,6 +428,31 @@ describe('/account/coins endpoint', () => {
                       symbol: '\\x',
                       metadata: {
                         policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
+                      }
+                    }
+                  },
+                  {
+                    value: '30',
+                    currency: {
+                      decimals: 0,
+                      symbol: '486173414e616d65',
+                      metadata: {
+                        policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d',
+                tokens: [
+                  {
+                    value: '10',
+                    currency: {
+                      decimals: 0,
+                      symbol: '7376c3a57274',
+                      metadata: {
+                        policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d'
                       }
                     }
                   }
@@ -423,7 +527,6 @@ describe('/account/coins endpoint', () => {
         }
       ])
     });
-
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
     expect(response.json()).toEqual({
       code: 4023,

--- a/cardano-rosetta-server/test/e2e/account/account-coins-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-coins-api.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable unicorn/prevent-abbreviations */
 /* eslint-disable camelcase */
 /* eslint-disable no-magic-numbers */
@@ -392,6 +393,140 @@ describe('/account/coins endpoint', () => {
       ]
     });
   });
+  test('should return all coins when ADA is specified as currency', async () => {
+    const response = await serverWithMultiassetsSupport.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vpqwk50mnckqnjvzdd7lhln2685xep2xf84jmhd9njd5kucdqnufv', [
+        {
+          decimals: 0,
+          symbol: '4154414441636f696e',
+          metadata: {
+            policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
+          }
+        },
+        {
+          decimals: 6,
+          symbol: 'ADA'
+        }
+      ])
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual({
+      block_identifier: latestBlockIdentifierMAServer,
+      coins: [
+        {
+          coin_identifier: { identifier: '7260f6b728bf49a95095da74ca9ec88cdbfb414eea81eaeb7d1939bbe6745b12:0' },
+          amount: {
+            currency: { decimals: 6, symbol: 'ADA' },
+            value: '2000000'
+          },
+          metadata: {
+            '7260f6b728bf49a95095da74ca9ec88cdbfb414eea81eaeb7d1939bbe6745b12:0': [
+              {
+                policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd',
+                tokens: [
+                  {
+                    value: '50',
+                    currency: {
+                      symbol: '42435348',
+                      decimals: 0,
+                      metadata: { policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd' }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          coin_identifier: { identifier: 'b352ea2f50d47851bda890ba2baed955f2f9aa3667ea69136454fa2a2de11ffe:0' },
+          amount: {
+            value: '5000000',
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            }
+          },
+          metadata: {
+            'b352ea2f50d47851bda890ba2baed955f2f9aa3667ea69136454fa2a2de11ffe:0': [
+              {
+                policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518',
+                tokens: [
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '4154414441636f696e',
+                      decimals: 0,
+                      metadata: { policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518' }
+                    }
+                  },
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '61646f736961',
+                      decimals: 0,
+                      metadata: { policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518' }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd',
+                tokens: [
+                  {
+                    value: '2',
+                    currency: {
+                      symbol: '42435348',
+                      decimals: 0,
+                      metadata: { policyId: '438918d2b57ef161987da24bc010b364dc852a70f9d5a3607d4c30cd' }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9',
+                tokens: [
+                  {
+                    value: '1',
+                    currency: {
+                      symbol: '676f6c64',
+                      decimals: 0,
+                      metadata: { policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9' }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          coin_identifier: { identifier: 'e58247e88790192246039816d27b58501c6686ab1f945cffec5262feedba4d23:0' },
+          amount: {
+            currency: { decimals: 6, symbol: 'ADA' },
+            value: '2000000'
+          },
+          metadata: {
+            'e58247e88790192246039816d27b58501c6686ab1f945cffec5262feedba4d23:0': [
+              {
+                policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9',
+                tokens: [
+                  {
+                    value: '5',
+                    currency: {
+                      symbol: '676f6c64',
+                      decimals: 0,
+                      metadata: { policyId: 'a52d2133008537f40f755932383466434543e87dbf8b99143fa7b5d9' }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    });
+  });
   test('should return coins for multi asset currency with empty name', async () => {
     const response = await serverWithMultiassetsSupport.inject({
       method: 'post',
@@ -464,6 +599,7 @@ describe('/account/coins endpoint', () => {
       ]
     });
   });
+
   test('should fail when querying for a currency with non hex string symbol', async () => {
     const invalidSymbol = 'thisIsANonHexString';
     const response = await server.inject({
@@ -533,6 +669,29 @@ describe('/account/coins endpoint', () => {
       message: 'Invalid policy id',
       retriable: false,
       details: { message: 'Given policy id is wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww' }
+    });
+  });
+  test('should fail when querying for a currency with a non hex policy id', async () => {
+    const invalidPolicy = 'thisIsANonHexString';
+    const response = await server.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vre2sc6w0zftnhselly9fd6kqqnmfmklful9zcmdh92mewszqs66y', [
+        {
+          decimals: 0,
+          symbol: '486173414e616d65',
+          metadata: {
+            policyId: invalidPolicy
+          }
+        }
+      ])
+    });
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({
+      code: 4023,
+      message: 'Invalid policy id',
+      retriable: false,
+      details: { message: 'Given policy id is thisIsANonHexString' }
     });
   });
 });

--- a/cardano-rosetta-server/test/e2e/account/account-coins-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-coins-api.test.ts
@@ -1,0 +1,189 @@
+/* eslint-disable camelcase */
+/* eslint-disable no-magic-numbers */
+import { FastifyInstance } from 'fastify';
+import StatusCodes from 'http-status-codes';
+import { Pool } from 'pg';
+import { CARDANO } from '../../../src/server/utils/constants';
+import { latestBlockIdentifier, latestBlockIdentifierMAServer, address1vpfCoins } from '../fixture-data';
+import { setupDatabase, setupServer } from '../utils/test-utils';
+
+const generatePayload = (blockchain: string, network: string, address: string) => ({
+  // eslint-disable-next-line camelcase
+  network_identifier: {
+    blockchain,
+    network
+  },
+  account_identifier: { address }
+});
+
+const ACCOUNT_COINS_ENDPOINT = '/account/coins';
+
+describe('/account/coins endpoint', () => {
+  let database: Pool;
+  let server: FastifyInstance;
+  let multiassetsDatabase: Pool;
+  let serverWithMultiassetsSupport: FastifyInstance;
+  beforeAll(async () => {
+    database = setupDatabase();
+    server = setupServer(database);
+    multiassetsDatabase = setupDatabase(process.env.DB_CONNECTION_STRING, 'launchpad');
+    serverWithMultiassetsSupport = setupServer(multiassetsDatabase);
+  });
+
+  afterAll(async () => {
+    await database.end();
+    await multiassetsDatabase.end();
+  });
+
+  test('should only consider coins till latest block', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(
+        CARDANO,
+        'mainnet',
+        'DdzFFzCqrhsdufpFxByLTQmktKJnTrudktaHq1nK2MAEDLXjz5kbRcr5prHi9gHb6m8pTvhgK6JbFDZA1LTiTcP6g8KuPSF1TfKP8ewp'
+      )
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual({
+      block_identifier: latestBlockIdentifier,
+      coins: [
+        {
+          coin_identifier: {
+            identifier: '4bcf79c0c2967986749fd0ae03f5b54a712d51b35672a3d974707c060c4d8dac:1'
+          },
+          amount: { value: '10509579714', currency: { decimals: 6, symbol: 'ADA' } }
+        },
+        {
+          coin_identifier: {
+            identifier: 'bcc57134d1bd588b00f40142f0fdc17db5f35047e3196cdf26aa7319524c0014:1'
+          },
+          amount: { value: '999800000', currency: { decimals: 6, symbol: 'ADA' } }
+        }
+      ]
+    });
+  });
+
+  test('should return empty if address doesnt exist', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(CARDANO, 'mainnet', 'fakeAddress')
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({
+      code: 4015,
+      message: 'Provided address is invalid',
+      retriable: true,
+      details: { message: 'fakeAddress' }
+    });
+  });
+  test('should have no coins for an account with zero balance', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(
+        CARDANO,
+        'mainnet',
+        'DdzFFzCqrhsszHTvbjTmYje5hehGbadkT6WgWbaqCy5XNxNttsPNF13eAjjBHYT7JaLJz2XVxiucam1EvwBRPSTiCrT4TNCBas4hfzic'
+      )
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual({
+      block_identifier: latestBlockIdentifier,
+      coins: []
+    });
+  });
+  test('should return no coins for stake accounts', async () => {
+    const response = await server.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(CARDANO, 'mainnet', 'stake1uyqq2a22arunrft3k9ehqc7yjpxtxjmvgndae80xw89mwyge9skyp')
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual({
+      block_identifier: latestBlockIdentifier,
+      coins: []
+    });
+  });
+
+  test('should return coins with multi assets currencies', async () => {
+    const response = await serverWithMultiassetsSupport.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc')
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json().block_identifier).toEqual(latestBlockIdentifierMAServer);
+    expect(response.json().coins).toHaveLength(address1vpfCoins.length);
+    address1vpfCoins.forEach(address1vpfCoin => expect(response.json().coins).toContainEqual(address1vpfCoin));
+  });
+
+  test('should return coins for ma with empty name', async () => {
+    const response = await serverWithMultiassetsSupport.inject({
+      method: 'post',
+      url: ACCOUNT_COINS_ENDPOINT,
+      payload: generatePayload(CARDANO, 'mainnet', 'addr_test1vre2sc6w0zftnhselly9fd6kqqnmfmklful9zcmdh92mewszqs66y')
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual({
+      block_identifier: latestBlockIdentifierMAServer,
+      coins: [
+        {
+          coin_identifier: { identifier: '95e1117558c2d075a4cd110ab0772460340f72a19ac5bc4691c6498e28055339:0' },
+          amount: {
+            currency: { decimals: 6, symbol: 'ADA' },
+            value: '4600000'
+          },
+          metadata: {
+            '95e1117558c2d075a4cd110ab0772460340f72a19ac5bc4691c6498e28055339:0': [
+              {
+                policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e',
+                tokens: [
+                  {
+                    value: '20',
+                    currency: {
+                      decimals: 0,
+                      symbol: '\\x',
+                      metadata: {
+                        policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
+                      }
+                    }
+                  },
+                  {
+                    value: '30',
+                    currency: {
+                      decimals: 0,
+                      symbol: '486173414e616d65',
+                      metadata: {
+                        policyId: '181aace621eea2b6cb367adb5000d516fa785087bad20308c072517e'
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d',
+                tokens: [
+                  {
+                    value: '10',
+                    currency: {
+                      decimals: 0,
+                      symbol: '7376c3a57274',
+                      metadata: {
+                        policyId: 'fc5a8a0aac159f035a147e5e2e3eb04fa3b5e67257c1b971647a717d'
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    });
+  });
+});

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/prevent-abbreviations */
 /* eslint-disable max-len */
 /* eslint-disable no-magic-numbers */
 import cbor from 'cbor';
@@ -3636,3 +3637,5 @@ export const balancesAtBlock213892 = [
     }
   }
 ];
+
+export const coinIdentifier95e1 = { identifier: '95e1117558c2d075a4cd110ab0772460340f72a19ac5bc4691c6498e28055339:0' };

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -33,7 +33,10 @@ export const latestBlockIdentifier = {
   hash: latestBlockHash,
   index: 4853177
 };
-
+export const latestBlockIdentifierMAServer = {
+  hash: '0700721626036f82476e0deb2eff43845c33823b646250fbf42fa0247149c8e0',
+  index: 382908
+};
 export const block23236WithTransactions = {
   block: {
     block_identifier: {
@@ -3594,78 +3597,6 @@ export const balancesAtBlock213891 = [
   }
 ];
 
-const coinId30d9 = { identifier: '30d97e64d1892ed7e03faf544318f167443a0153c244305df9b0f796a0386c8b:0' };
-export const coinsAtBlock213891 = [
-  {
-    coin_identifier: coinId30d9,
-    amount: {
-      value: '299994729944',
-      currency: {
-        decimals: 6,
-        symbol: 'ADA'
-      }
-    },
-    metadata: {
-      '30d97e64d1892ed7e03faf544318f167443a0153c244305df9b0f796a0386c8b:0': [
-        {
-          policyId: '06e5f0ade7121aaefa0e7ec53cac61820d774de0c12c83e8597627ff',
-          tokens: [
-            {
-              value: '10',
-              currency: {
-                decimals: 0,
-                symbol: '74657374746f6b656e',
-                metadata: {
-                  policyId: '06e5f0ade7121aaefa0e7ec53cac61820d774de0c12c83e8597627ff'
-                }
-              }
-            }
-          ]
-        },
-        {
-          policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518',
-          tokens: [
-            {
-              value: '95',
-              currency: {
-                decimals: 0,
-                symbol: '4154414441636f696e',
-                metadata: {
-                  policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
-                }
-              }
-            },
-            {
-              value: '2500',
-              currency: {
-                decimals: 0,
-                symbol: '6d616368746c636f696e',
-                metadata: {
-                  policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
-                }
-              }
-            }
-          ]
-        },
-        {
-          policyId: 'ecd07b4ef62f37a68d145de8efd60c53d288dd5ffc641215120cc3db',
-          tokens: [
-            {
-              value: '500',
-              currency: {
-                decimals: 0,
-                symbol: '6d616368746c32636f696e',
-                metadata: {
-                  policyId: 'ecd07b4ef62f37a68d145de8efd60c53d288dd5ffc641215120cc3db'
-                }
-              }
-            }
-          ]
-        }
-      ]
-    }
-  }
-];
 export const balancesAtBlock213892 = [
   {
     value: '299994547239',
@@ -3702,64 +3633,6 @@ export const balancesAtBlock213892 = [
       metadata: {
         policyId: 'ecd07b4ef62f37a68d145de8efd60c53d288dd5ffc641215120cc3db'
       }
-    }
-  }
-];
-
-const coinId1a04 = { identifier: '1a04005e5459b07a6353f5c1a9b1066d5969638b681923af6cb0601cf8c57495:0' };
-export const coinsAtBlock213892 = [
-  {
-    coin_identifier: coinId1a04,
-    amount: {
-      value: '299994547239',
-      currency: {
-        decimals: 6,
-        symbol: 'ADA'
-      }
-    },
-    metadata: {
-      '1a04005e5459b07a6353f5c1a9b1066d5969638b681923af6cb0601cf8c57495:0': [
-        {
-          policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518',
-          tokens: [
-            {
-              value: '95',
-              currency: {
-                decimals: 0,
-                symbol: '4154414441636f696e',
-                metadata: {
-                  policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
-                }
-              }
-            },
-            {
-              value: '2500',
-              currency: {
-                decimals: 0,
-                symbol: '6d616368746c636f696e',
-                metadata: {
-                  policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518'
-                }
-              }
-            }
-          ]
-        },
-        {
-          policyId: 'ecd07b4ef62f37a68d145de8efd60c53d288dd5ffc641215120cc3db',
-          tokens: [
-            {
-              value: '500',
-              currency: {
-                decimals: 0,
-                symbol: '6d616368746c32636f696e',
-                metadata: {
-                  policyId: 'ecd07b4ef62f37a68d145de8efd60c53d288dd5ffc641215120cc3db'
-                }
-              }
-            }
-          ]
-        }
-      ]
     }
   }
 ];

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -104,6 +104,8 @@ const allow = {
       message: 'Asset value is required for token asset',
       retriable: false
     },
+    { code: 4023, message: 'Invalid policy id', retriable: false },
+    { code: 4024, message: 'Invalid token name', retriable: false },
     {
       code: 5000,
       message: 'An error occurred',

--- a/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
@@ -1,5 +1,5 @@
 import { mapToAccountBalanceResponse } from '../../../src/server/utils/data-mapper';
-import { BlockUtxos } from '../../../src/server/models';
+import { BlockUtxosMultiAssets } from '../../../src/server/models';
 
 describe('Data Mapper', () => {
   describe('mapToAccountBalanceResponse', () => {
@@ -8,7 +8,7 @@ describe('Data Mapper', () => {
     // addr_test1vrd26p8d9dlknc4fhevzudcfzuul5qm2znquytugqcw583czzqrpm at
     // 1630464 (computed: 37999999978288983ADA, live: 37999999978288984ADA)"
     it('Should properly process BigInt balances', () => {
-      const blockUtxos: BlockUtxos = {
+      const blockUtxos: BlockUtxosMultiAssets = {
         block: {
           hash: '032349b3b569bc1ecb266b79ae28a5e79834377562a627f0dc99fa3cd1bfd546',
           number: 1627535,

--- a/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/data-mapper.test.ts
@@ -46,21 +46,6 @@ describe('Data Mapper', () => {
           hash: '032349b3b569bc1ecb266b79ae28a5e79834377562a627f0dc99fa3cd1bfd546',
           index: 1627535
         }
-        // coins: [
-        //   {
-        //     amount: {
-        //       currency: {
-        //         decimals: 6,
-        //         symbol: 'ADA'
-        //       },
-        //       value: '37999999989620601'
-        //     },
-        //     // eslint-disable-next-line camelcase
-        //     coin_identifier: {
-        //       identifier: 'c09c523b0a94837dacf08e30f8cc6d5915786b883f822981ea2012551f8699ce:1'
-        //     }
-        //   }
-        // ]
       });
     });
   });


### PR DESCRIPTION
# Description

Adds `/account/coins` endpoint according to Rosetta v1.4.10.

# Proposed Solution

In order to allow querying by specified currencies, the utxo query has been modified. Also, the `data-mapper'`s method that used to map the `accountBalanceResponse` has been simplified and a new one has been created to map `accountCoinsResponse`.

# Important Changes Introduced

New endpoint `accountCoins` at `account-controller`.

# References

Closes #335
