### PR TITLE
Increment max body limit

### DIFF
--- a/cardano-rosetta-server/README.md
+++ b/cardano-rosetta-server/README.md
@@ -39,6 +39,8 @@ PAGE_SIZE=25
 DEFAULT_RELATIVE_TTL=1000
 # Exemption types file path
 EXEMPTION_TYPES_PATH="/etc/node/exemptions.json"
+# request payload limit
+BODY_LIMIT=1048576
 ```
 
 ### Install packages from offline cache

--- a/cardano-rosetta-server/src/server/server.ts
+++ b/cardano-rosetta-server/src/server/server.ts
@@ -29,7 +29,7 @@ const buildServer = (
   logLevel: string,
   extraParameters: ExtraParams
 ): fastify.FastifyInstance<Server, IncomingMessage, ServerResponse> => {
-  const server = fastify({ logger: { level: logLevel } });
+  const server = fastify({ logger: { level: logLevel }, bodyLimit: process.env.BODY_LIMIT });
   const { networkId, pageSize } = extraParameters;
   server.register(fastifyBlipp);
   server.register(openapiGlue, {

--- a/cardano-rosetta-server/src/types/app.d.ts
+++ b/cardano-rosetta-server/src/types/app.d.ts
@@ -11,5 +11,6 @@ declare namespace NodeJS {
     CARDANO_NODE_PATH: string;
     TOPOLOGY_FILE_PATH: string;
     EXEMPTION_TYPES_PATH: string;
+    BODY_LIMIT: number;
   }
 }


### PR DESCRIPTION
# Description

Body limit of requests can be increased by using the new env var `BODY_LIMIT`, if it is not present then default will be set which is 1048576 (1MiB)