### PR TITLE
Feat/add pool registration at blocks endpoint

### DIFF
--- a/cardano-rosetta-server/src/server/controllers/block-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/block-controller.ts
@@ -1,11 +1,8 @@
 import { FastifyRequest } from 'fastify';
 import { BlockService } from '../services/block-service';
+import { CardanoService } from '../services/cardano-services';
 import { ErrorFactory } from '../utils/errors';
-import {
-  getNetworkIdentifierByRequestParameters,
-  mapToRosettaBlock,
-  mapToRosettaTransaction
-} from '../utils/data-mapper';
+import { mapToRosettaBlock, mapToRosettaTransaction } from '../utils/data-mapper';
 import { withNetworkValidation } from './controllers-helper';
 import { NetworkService } from '../services/network-service';
 
@@ -18,7 +15,12 @@ export interface BlockController {
   ): Promise<Components.Schemas.BlockTransactionResponse | Components.Schemas.Error>;
 }
 
-const configure = (blockService: BlockService, PAGE_SIZE: number, networkService: NetworkService): BlockController => ({
+const configure = (
+  blockService: BlockService,
+  cardanoService: CardanoService,
+  PAGE_SIZE: number,
+  networkService: NetworkService
+): BlockController => ({
   block: async request =>
     withNetworkValidation(
       request.body.network_identifier,
@@ -33,10 +35,11 @@ const configure = (blockService: BlockService, PAGE_SIZE: number, networkService
         if (block !== null) {
           logger.info('[block] Block was found');
           const transactionsFound = await blockService.findTransactionsByBlock(logger, block);
+          const { poolDeposit } = await cardanoService.getDepositParameters(logger);
           if (transactionsFound.length > PAGE_SIZE) {
             logger.info('[block] Returning only transactions hashes since the number of them is bigger than PAGE_SIZE');
             return {
-              block: mapToRosettaBlock(block, []),
+              block: mapToRosettaBlock(block, [], poolDeposit),
               // eslint-disable-next-line camelcase
               other_transactions: transactionsFound.map(transaction => ({
                 hash: transaction.hash
@@ -47,7 +50,7 @@ const configure = (blockService: BlockService, PAGE_SIZE: number, networkService
           const transactions = await blockService.fillTransactions(logger, transactionsFound);
           logger.info(transactions, '[block] transactions already filled');
           return {
-            block: mapToRosettaBlock(block, transactions)
+            block: mapToRosettaBlock(block, transactions, poolDeposit)
           };
         }
         logger.error('[block] Block was not found');
@@ -79,7 +82,8 @@ const configure = (blockService: BlockService, PAGE_SIZE: number, networkService
           logger.error('[blockTransaction] No transaction found');
           throw ErrorFactory.transactionNotFound();
         }
-        const response = mapToRosettaTransaction(transaction);
+        const { poolDeposit } = await cardanoService.getDepositParameters(logger);
+        const response = mapToRosettaTransaction(transaction, poolDeposit);
         logger.debug({ response }, '[blockTransaction] Returning response ');
         return {
           transaction: response

--- a/cardano-rosetta-server/src/server/controllers/block-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/block-controller.ts
@@ -1,7 +1,11 @@
 import { FastifyRequest } from 'fastify';
 import { BlockService } from '../services/block-service';
 import { ErrorFactory } from '../utils/errors';
-import { mapToRosettaBlock, mapToRosettaTransaction } from '../utils/data-mapper';
+import {
+  getNetworkIdentifierByRequestParameters,
+  mapToRosettaBlock,
+  mapToRosettaTransaction
+} from '../utils/data-mapper';
 import { withNetworkValidation } from './controllers-helper';
 import { NetworkService } from '../services/network-service';
 

--- a/cardano-rosetta-server/src/server/controllers/controllers.ts
+++ b/cardano-rosetta-server/src/server/controllers/controllers.ts
@@ -20,7 +20,7 @@ export const configure = (
   networkId: string,
   pageSize: number
 ): Controllers => ({
-  ...blockController(services.blockService, pageSize, services.networkService),
+  ...blockController(services.blockService, services.cardanoService, pageSize, services.networkService),
   ...accountController(services.blockService, services.cardanoService, services.networkService),
   ...networkController(services.networkService, cardanoNode),
   ...constructionController(services.constructionService, services.cardanoService, cardanoCli, services.networkService)

--- a/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
+++ b/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
@@ -185,6 +185,32 @@ WHERE
   tx.hash = ANY ($1)
 `;
 
+export interface FindTransactionPoolRegistrationsData extends FindTransactionFieldResult {
+  poolId: number;
+  updateId: number;
+  vrfKeyHash: Buffer;
+  pledge: string;
+  margin: string;
+  cost: string;
+  address: Buffer;
+  poolHash: Buffer;
+  metadataUrl: string;
+  metadataHash: Buffer;
+}
+
+export interface FindTransactionPoolOwners extends FindTransactionFieldResult {
+  poolId: number;
+  owner: Buffer;
+}
+export interface FindTransactionPoolRelays extends FindTransactionFieldResult {
+  updateId: number;
+  vrfKeyHash: Buffer;
+  ipv4: string;
+  ipv6: string;
+  dnsName: string;
+  port: string;
+}
+
 const findTransactionRegistrations = `
 SELECT 
   tx.deposit as "amount",
@@ -252,6 +278,61 @@ export interface FindMaBalance {
   policy: Buffer;
   value: string;
 }
+
+const poolRegistrationQuery = `
+  WITH pool_registration AS (
+  SELECT
+    tx.hash as "txHash",
+    pu.id as "updateId",
+    ph.id as "poolId",
+    pu.vrf_key_hash as "vrfKeyHash",
+    pu.pledge as pledge,
+    pu.margin as margin,
+    pu.fixed_cost as cost,
+    pu.reward_addr as address,
+    ph.hash_raw as "poolHash",
+    pm.url as "metadataUrl",
+    pm.hash as "metadataHash"
+  FROM pool_update pu
+  JOIN tx 
+  ON pu.registered_tx_id = tx.id
+  JOIN pool_hash ph
+  ON ph.id = pu.hash_id
+  LEFT JOIN pool_meta_data pm
+  ON pu.meta_id = pm.id
+  WHERE
+    tx.hash = ANY ($1)
+  )
+`;
+
+const FindTransactionPoolRegistrationsData = `
+  ${poolRegistrationQuery}
+    SELECT *
+    FROM pool_registration
+`;
+
+const findTransactionPoolOwners = `
+${poolRegistrationQuery}
+    SELECT 
+      po.pool_hash_id AS "poolId",
+      po.hash AS "owner"
+    FROM pool_registration pr
+    JOIN pool_owner po
+    ON  po.pool_hash_id = pr."poolId"
+`;
+
+const findTransactionPoolRelays = `
+${poolRegistrationQuery}
+    SELECT
+      prelay.update_id as "updateId",
+      prelay.ipv4 as ipv4,
+      prelay.ipv6 as ipv6,
+      prelay.port as port,
+      prelay.dns_name as "dnsName"
+    FROM pool_registration pr
+    JOIN pool_relay prelay
+    ON prelay.update_id = pr."updateId"
+`;
 
 const utxoQuery = `
 WITH utxo AS (
@@ -325,20 +406,24 @@ const findBalanceByAddressAndBlock = `
 `;
 
 const Queries = {
+  findBalanceByAddressAndBlock,
   findBlock,
-  findTransactionsByBlock,
-  findTransactionByHashAndBlock,
-  findTransactionsInputs,
-  findTransactionsOutputs,
-  findTransactionWithdrawals,
-  findTransactionRegistrations,
-  findTransactionDeregistrations,
-  findTransactionDelegations,
   findLatestBlockNumber,
   findGenesisBlock,
-  findUtxoByAddressAndBlock,
   findMaBalanceByAddressAndBlock,
-  findBalanceByAddressAndBlock
+  findTransactionByHashAndBlock,
+  findTransactionDelegations,
+  findTransactionDeregistrations,
+  findTransactionPoolOwners,
+  findTransactionPoolRelays,
+  FindTransactionPoolRegistrationsData,
+  findTransactionRegistrations,
+  findTransactionWithdrawals,
+  findTransactionsByBlock,
+  findTransactionsInputs,
+  findTransactionsOutputs,
+
+  findUtxoByAddressAndBlock
 };
 
 export default Queries;

--- a/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
+++ b/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
@@ -283,6 +283,7 @@ const poolRegistrationQuery = `
   WITH pool_registration AS (
   SELECT
     tx.hash as "txHash",
+    tx.id as "txId",
     pu.id as "updateId",
     ph.id as "poolId",
     pu.vrf_key_hash as "vrfKeyHash",
@@ -318,7 +319,8 @@ ${poolRegistrationQuery}
       po.hash AS "owner"
     FROM pool_registration pr
     JOIN pool_owner po
-    ON  po.pool_hash_id = pr."poolId"
+    ON  (po.pool_hash_id = pr."poolId" 
+    AND po.registered_tx_id = pr."txId")
 `;
 
 const findTransactionPoolRelays = `

--- a/cardano-rosetta-server/src/server/index.ts
+++ b/cardano-rosetta-server/src/server/index.ts
@@ -9,7 +9,7 @@ import * as Services from './services/services';
 import * as CardanoCli from './utils/cardano/cli/cardanonode-cli';
 import * as CardanoNode from './utils/cardano/cli/cardano-node';
 import { Environment, parseEnvironment } from './utils/environment-parser';
-import { LinearFeeParameters } from './services/cardano-services';
+import { LinearFeeParameters, DepositsParameters } from './services/cardano-services';
 
 // FIXME: validate the following paraemeters when implementing (2)
 // https://github.com/input-output-hk/cardano-rosetta/issues/101
@@ -20,8 +20,10 @@ const linearFeeParameters: LinearFeeParameters = {
   minFeeA: genesis.protocolParams.minFeeA,
   minFeeB: genesis.protocolParams.minFeeB
 };
-const keyDeposit = genesis.protocolParams.keyDeposit;
-const poolDeposit = genesis.protocolParams.poolDeposit;
+const depositsParameters: DepositsParameters = {
+  keyDeposit: genesis.protocolParams.keyDeposit,
+  poolDeposit: genesis.protocolParams.poolDeposit
+};
 
 const start = async (databaseInstance: Pool) => {
   let server;
@@ -39,8 +41,7 @@ const start = async (databaseInstance: Pool) => {
       environment.TOPOLOGY_FILE,
       environment.DEFAULT_RELATIVE_TTL,
       linearFeeParameters,
-      keyDeposit,
-      poolDeposit
+      depositsParameters
     );
     server = buildServer(services, cardanoCli, cardanoNode, environment.LOGGER_LEVEL, {
       networkId,

--- a/cardano-rosetta-server/src/server/index.ts
+++ b/cardano-rosetta-server/src/server/index.ts
@@ -21,6 +21,7 @@ const linearFeeParameters: LinearFeeParameters = {
   minFeeB: genesis.protocolParams.minFeeB
 };
 const keyDeposit = genesis.protocolParams.keyDeposit;
+const poolDeposit = genesis.protocolParams.poolDeposit;
 
 const start = async (databaseInstance: Pool) => {
   let server;
@@ -38,7 +39,8 @@ const start = async (databaseInstance: Pool) => {
       environment.TOPOLOGY_FILE,
       environment.DEFAULT_RELATIVE_TTL,
       linearFeeParameters,
-      keyDeposit
+      keyDeposit,
+      poolDeposit
     );
     server = buildServer(services, cardanoCli, cardanoNode, environment.LOGGER_LEVEL, {
       networkId,

--- a/cardano-rosetta-server/src/server/models.ts
+++ b/cardano-rosetta-server/src/server/models.ts
@@ -86,6 +86,40 @@ export interface Deregistration {
   amount: string;
 }
 
+export interface PoolRelay {
+  ipv4?: string;
+  ipv6?: string;
+  dnsName?: string;
+  port?: string;
+}
+
+export interface TransactionPoolRegistrations {
+  txHash: Buffer;
+  vrfKeyHash: Buffer;
+  pledge: string;
+  margin: string;
+  cost: string;
+  address: Buffer;
+  poolHash: Buffer;
+  owners: Buffer[];
+  relays: PoolRelay[];
+  metadataUrl?: string;
+  metadataHash?: Buffer;
+}
+
+export interface PoolRegistration {
+  vrfKeyHash: string;
+  pledge: string;
+  margin: string;
+  cost: string;
+  address: string;
+  poolHash: string;
+  owners: string[];
+  relays: PoolRelay[];
+  metadataUrl?: string;
+  metadataHash?: string;
+}
+
 export interface Delegation {
   stakeAddress: string;
   poolHash: string;
@@ -105,6 +139,7 @@ export interface PopulatedTransaction extends Transaction {
   registrations: Registration[];
   deregistrations: Deregistration[];
   delegations: Delegation[];
+  poolRegistrations: PoolRegistration[];
 }
 
 export interface Network {

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1114,7 +1114,7 @@
       },
       "PoolRegistrationParams": {
         "type": "object",
-        "required": ["vrfKeyHash", "pledge", "cost", "poolOwners", "relays"],
+        "required": ["vrfKeyHash", "pledge", "cost", "poolOwners", "relays", "margin"],
         "properties": {
           "vrfKeyHash": {
             "type": "string"
@@ -1139,6 +1139,9 @@
               "$ref": "#/components/schemas/Relay"
             }
           },
+          "margin": {
+            "$ref": "#/components/schemas/PoolMargin"
+          },
           "poolMetadata": {
             "$ref": "#/components/schemas/PoolMetadata"
           }
@@ -1159,6 +1162,18 @@
             "type": "string"
           },
           "port": {
+            "type": "string"
+          }
+        }
+      },
+      "PoolMargin": {
+        "type": "object",
+        "required": ["numerator", "denominator"],
+        "properties": {
+          "numerator": {
+            "type": "string"
+          },
+          "denominator": {
             "type": "string"
           }
         }

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1145,6 +1145,9 @@
           "margin": {
             "$ref": "#/components/schemas/PoolMargin"
           },
+          "margin_percentage": {
+            "type": "string"
+          },
           "poolMetadata": {
             "$ref": "#/components/schemas/PoolMetadata"
           }

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1103,9 +1103,9 @@
               "$ref": "#/components/schemas/TokenBundleItem"
             }
           },
-          "poolRegistrationCert":{
+          "poolRegistrationCert": {
             "description": "Certificate of a pool registration encoded as hex string",
-            "type": "string" 
+            "type": "string"
           },
           "poolRegistrationParams": {
             "$ref": "#/components/schemas/PoolRegistrationParams"
@@ -1114,7 +1114,7 @@
       },
       "PoolRegistrationParams": {
         "type": "object",
-        "required": ["vrfKeyHash", "pledge", "cost", "rewardAccount", "poolOwners", "relays"],
+        "required": ["vrfKeyHash", "pledge", "cost", "poolOwners", "relays"],
         "properties": {
           "vrfKeyHash": {
             "type": "string"
@@ -1125,9 +1125,6 @@
           },
           "cost": {
             "description": "Operational costs per epoch lovelace",
-            "type": "string"
-          },
-          "rewardAccount": {
             "type": "string"
           },
           "poolOwners": {
@@ -1149,7 +1146,9 @@
       },
       "Relay": {
         "type": "object",
+        "required": ["type"],
         "properties": {
+          "type": { "type": "string" },
           "ipv4": {
             "type": "string"
           },

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1103,6 +1103,10 @@
               "$ref": "#/components/schemas/TokenBundleItem"
             }
           },
+          "poolRegistrationCert":{
+            "description": "Certificate of a pool registration encoded as hex string",
+            "type": "string" 
+          },
           "poolRegistrationParams": {
             "$ref": "#/components/schemas/PoolRegistrationParams"
           }

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1114,9 +1114,12 @@
       },
       "PoolRegistrationParams": {
         "type": "object",
-        "required": ["vrfKeyHash", "pledge", "cost", "poolOwners", "relays", "margin"],
+        "required": ["vrfKeyHash", "pledge", "cost", "poolOwners", "relays", "margin", "rewardAddress"],
         "properties": {
           "vrfKeyHash": {
+            "type": "string"
+          },
+          "rewardAddress": {
             "type": "string"
           },
           "pledge": {
@@ -1149,7 +1152,6 @@
       },
       "Relay": {
         "type": "object",
-        "required": ["type"],
         "properties": {
           "type": { "type": "string" },
           "ipv4": {

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1114,7 +1114,7 @@
       },
       "PoolRegistrationParams": {
         "type": "object",
-        "required": ["vrfKeyHash", "pledge", "cost", "poolOwners", "relays", "margin", "rewardAddress"],
+        "required": ["vrfKeyHash", "pledge", "cost", "poolOwners", "relays", "rewardAddress"],
         "properties": {
           "vrfKeyHash": {
             "type": "string"

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1086,7 +1086,7 @@
             "description": "If it's a registration operation, the amount will re returned here.",
             "$ref": "#/components/schemas/Amount"
           },
-          "fundAmount": {
+          "refundAmount": {
             "description": "If it's a deregistration operation, the amount will re returned here.",
             "$ref": "#/components/schemas/Amount"
           },

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1102,6 +1102,73 @@
             "items": {
               "$ref": "#/components/schemas/TokenBundleItem"
             }
+          },
+          "poolRegistrationParams": {
+            "$ref": "#/components/schemas/PoolRegistrationParams"
+          }
+        }
+      },
+      "PoolRegistrationParams": {
+        "type": "object",
+        "required": ["vrfKeyHash", "pledge", "cost", "rewardAccount", "poolOwners", "relays"],
+        "properties": {
+          "vrfKeyHash": {
+            "type": "string"
+          },
+          "pledge": {
+            "description": "Lovelace amount to pledge",
+            "type": "string"
+          },
+          "cost": {
+            "description": "Operational costs per epoch lovelace",
+            "type": "string"
+          },
+          "rewardAccount": {
+            "type": "string"
+          },
+          "poolOwners": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "relays": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Relay"
+            }
+          },
+          "poolMetadata": {
+            "$ref": "#/components/schemas/PoolMetadata"
+          }
+        }
+      },
+      "Relay": {
+        "type": "object",
+        "properties": {
+          "ipv4": {
+            "type": "string"
+          },
+          "ipv6": {
+            "type": "string"
+          },
+          "dnsName": {
+            "type": "string"
+          },
+          "port": {
+            "type": "string"
+          }
+        }
+      },
+      "PoolMetadata": {
+        "type": "object",
+        "required": ["url", "hash"],
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "hash": {
+            "type": "string"
           }
         }
       },

--- a/cardano-rosetta-server/src/server/services/cardano-services.ts
+++ b/cardano-rosetta-server/src/server/services/cardano-services.ts
@@ -192,6 +192,13 @@ export interface CardanoService {
     transaction: string,
     extraData: Components.Schemas.Operation[]
   ): TransactionParsed;
+
+  /**
+   * Returns deposit parameters
+   *
+   * @param logger
+   */
+  getDepositParameters(logger: Logger): DepositsParameters;
 }
 
 const calculateFee = (
@@ -464,6 +471,10 @@ const configure = (
       );
       throw ErrorFactory.cantCreateUnsignedTransactionFromBytes();
     }
+  },
+  getDepositParameters(logger) {
+    logger.info(depositsParameters, '[getDepositParameters] About to return deposit parameters');
+    return depositsParameters;
   }
 });
 

--- a/cardano-rosetta-server/src/server/services/cardano-services.ts
+++ b/cardano-rosetta-server/src/server/services/cardano-services.ts
@@ -35,6 +35,8 @@ import { isEd25519KeyHash } from '../utils/validations';
 export interface Signatures {
   signature: string;
   publicKey: string;
+  chain_code?: string;
+  attributes?: string;
 }
 export interface UnsignedTransaction {
   hash: string;

--- a/cardano-rosetta-server/src/server/services/services.ts
+++ b/cardano-rosetta-server/src/server/services/services.ts
@@ -1,6 +1,6 @@
 import { Repositories } from '../db/repositories';
 import blockService, { BlockService } from './block-service';
-import cardanoService, { CardanoService, LinearFeeParameters } from './cardano-services';
+import cardanoService, { CardanoService, LinearFeeParameters, DepositsParameters } from './cardano-services';
 import constructionService, { ConstructionService } from './construction-service';
 import networkService, { NetworkService, TopologyConfig } from './network-service';
 
@@ -23,12 +23,11 @@ export const configure = (
   topologyFile: TopologyConfig,
   DEFAULT_RELATIVE_TTL: number,
   linearFeeParameters: LinearFeeParameters,
-  minKeyDeposit: number,
-  poolDeposit: number
+  depositsParameters: DepositsParameters
   // FIXME: we can group networkId and networkMagic in a new type
   // eslint-disable-next-line max-params
 ): Services => {
-  const cardanoServiceInstance = cardanoService(linearFeeParameters, minKeyDeposit, poolDeposit);
+  const cardanoServiceInstance = cardanoService(linearFeeParameters, depositsParameters);
   const blockServiceInstance = blockService(repositories.blockchainRepository, cardanoServiceInstance);
   return {
     blockService: blockServiceInstance,

--- a/cardano-rosetta-server/src/server/services/services.ts
+++ b/cardano-rosetta-server/src/server/services/services.ts
@@ -23,11 +23,12 @@ export const configure = (
   topologyFile: TopologyConfig,
   DEFAULT_RELATIVE_TTL: number,
   linearFeeParameters: LinearFeeParameters,
-  minKeyDeposit: number
+  minKeyDeposit: number,
+  poolDeposit: number
   // FIXME: we can group networkId and networkMagic in a new type
   // eslint-disable-next-line max-params
 ): Services => {
-  const cardanoServiceInstance = cardanoService(linearFeeParameters, minKeyDeposit);
+  const cardanoServiceInstance = cardanoService(linearFeeParameters, minKeyDeposit, poolDeposit);
   const blockServiceInstance = blockService(repositories.blockchainRepository, cardanoServiceInstance);
   return {
     blockService: blockServiceInstance,

--- a/cardano-rosetta-server/src/server/utils/cardano/operations-processor.ts
+++ b/cardano-rosetta-server/src/server/utils/cardano/operations-processor.ts
@@ -303,11 +303,20 @@ const validateAndParsePoolRegistationParameters = (
   logger: Logger,
   poolRegistrationParameters: Components.Schemas.PoolRegistrationParams
 ) => {
+  const denominator = poolRegistrationParameters?.margin?.denominator;
+  const numerator = poolRegistrationParameters?.margin?.numerator;
+
+  if (!denominator || !numerator) {
+    logger.error(
+      '[validateAndParsePoolRegistationParameters] Missing margin parameter at pool registration parameters'
+    );
+    throw ErrorFactory.invalidPoolRegistrationParameters('Missing margin parameter at pool registration parameters');
+  }
   const poolParameters: { [key: string]: string } = {
     cost: poolRegistrationParameters.cost,
     pledge: poolRegistrationParameters.pledge,
-    numerator: poolRegistrationParameters.margin.numerator,
-    denominator: poolRegistrationParameters.margin.denominator
+    numerator,
+    denominator
   };
   // eslint-disable-next-line unicorn/prevent-abbreviations
   const parsedPoolParams: { [key: string]: BigNum } = {};

--- a/cardano-rosetta-server/src/server/utils/cardano/operations-processor.ts
+++ b/cardano-rosetta-server/src/server/utils/cardano/operations-processor.ts
@@ -148,7 +148,7 @@ const processStakeKeyRegistration = (
 
 const validateAndParsePoolKeyHash = (logger: Logger, poolKeyHash?: string): CardanoWasm.Ed25519KeyHash => {
   if (!poolKeyHash) {
-    logger.error('[validateAndParsePoolKeyHash] no pool key hash provided for stake delegation');
+    logger.error('[validateAndParsePoolKeyHash] no pool key hash provided');
     throw ErrorFactory.missingPoolKeyError();
   }
   let parsedPoolKeyHash: CardanoWasm.Ed25519KeyHash;

--- a/cardano-rosetta-server/src/server/utils/cardano/transactions-processor.ts
+++ b/cardano-rosetta-server/src/server/utils/cardano/transactions-processor.ts
@@ -77,6 +77,17 @@ const parsePoolRelays = (poolParameters: CardanoWasm.PoolParams): Array<Componen
   return poolRelays;
 };
 
+const parsePoolMargin = (poolParameters: CardanoWasm.PoolParams): Components.Schemas.PoolMargin => ({
+  denominator: poolParameters
+    .margin()
+    .denominator()
+    .to_str(),
+  numerator: poolParameters
+    .margin()
+    .numerator()
+    .to_str()
+});
+
 const parsePoolRegistration = (
   poolRegistration: CardanoWasm.PoolRegistration
 ): Components.Schemas.PoolRegistrationParams => {
@@ -87,6 +98,7 @@ const parsePoolRegistration = (
     cost: poolParameters.cost().to_str(),
     poolOwners: parsePoolOwners(poolParameters),
     relays: parsePoolRelays(poolParameters),
+    margin: parsePoolMargin(poolParameters),
     poolMetadata: parsePoolMetadata(poolParameters)
   };
 };
@@ -185,7 +197,6 @@ const parseCertToOperation = (
   hash: string,
   type: string,
   address: string
-  // eslint-disable-next-line max-params
 ): Components.Schemas.Operation => {
   const operation: Components.Schemas.Operation = {
     operation_identifier: { index },

--- a/cardano-rosetta-server/src/server/utils/cardano/transactions-processor.ts
+++ b/cardano-rosetta-server/src/server/utils/cardano/transactions-processor.ts
@@ -1,7 +1,7 @@
-import CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
+import CardanoWasm, { PoolParams } from '@emurgo/cardano-serialization-lib-nodejs';
 import cbor from 'cbor';
 import { Logger } from 'fastify';
-import { ADA, ADA_DECIMALS, CurveType, OperationType } from '../constants';
+import { ADA, ADA_DECIMALS, CurveType, OperationType, StakeAddressPrefix } from '../constants';
 import { mapAmount } from '../data-mapper';
 import { ErrorFactory } from '../errors';
 import { hexFormatter } from '../formatters';
@@ -27,6 +27,71 @@ const parseInputToOperation = (input: CardanoWasm.TransactionInput, index: numbe
   status: '',
   type: OperationType.INPUT
 });
+
+// eslint-disable-next-line consistent-return
+const parsePoolMetadata = (poolParameters: CardanoWasm.PoolParams): Components.Schemas.PoolMetadata | undefined => {
+  const metadata = poolParameters.pool_metadata();
+  if (metadata) {
+    const hash = Buffer.from(metadata.metadata_hash().to_bytes()).toString();
+    const url = Buffer.from(metadata.url().to_bytes()).toString();
+    return { url, hash };
+  }
+};
+
+const parsePoolOwners = (poolParameters: CardanoWasm.PoolParams): Array<string> => {
+  const poolOwners: Array<string> = [];
+  const ownersCount = poolParameters.pool_owners().len();
+  for (let i = 0; i <= ownersCount; i++) {
+    const owner = poolParameters.pool_owners().get(i);
+    poolOwners.push(Buffer.from(owner.to_bytes()).toString('hex'));
+  }
+  return poolOwners;
+};
+
+const parsePoolRelays = (poolParameters: CardanoWasm.PoolParams): Array<Components.Schemas.Relay> => {
+  const poolRelays: Array<Components.Schemas.Relay> = [];
+  const relaysCount = poolParameters.relays().len();
+  for (let i = 0; i <= relaysCount; i++) {
+    const relay = poolParameters.relays().get(i);
+    const multiHostRelay = relay.as_multi_host_name();
+    if (multiHostRelay) {
+      poolRelays.push({ dnsName: multiHostRelay.dns_name().record() });
+      continue;
+    }
+    const singleHostName = relay.as_single_host_name();
+    if (singleHostName) {
+      poolRelays.push({ dnsName: singleHostName.dns_name().record(), port: singleHostName.port()?.toString() });
+      continue;
+    }
+    const singleHostAddr = relay.as_single_host_addr();
+    if (singleHostAddr) {
+      const ipv4 = singleHostAddr.ipv4() ? Buffer.from(singleHostAddr.ipv4()!.to_bytes).toString('hex') : undefined;
+      const ipv6 = singleHostAddr.ipv6() ? Buffer.from(singleHostAddr.ipv6()!.to_bytes).toString('hex') : undefined;
+      poolRelays.push({ port: singleHostAddr.port()?.toString(), ipv4, ipv6 });
+    }
+  }
+  return poolRelays;
+};
+
+const parsePoolRegistration = (
+  poolRegistration: CardanoWasm.PoolRegistration,
+  network: number
+): Components.Schemas.PoolRegistrationParams => {
+  const poolParameters = poolRegistration.pool_params();
+  const rewardAccount = poolParameters
+    .reward_account()
+    .to_address()
+    .to_bech32(getAddressPrefix(network, StakeAddressPrefix));
+  return {
+    vrfKeyHash: Buffer.from(poolParameters.operator().to_bytes()).toString('hex'),
+    pledge: Buffer.from(poolParameters.pledge().to_bytes()).toString(),
+    cost: Buffer.from(poolParameters.cost().to_bytes()).toString(),
+    rewardAccount,
+    poolOwners: parsePoolOwners(poolParameters),
+    relays: parsePoolRelays(poolParameters),
+    poolMetadata: parsePoolMetadata(poolParameters)
+  };
+};
 
 /**
  * Create policy id or asset name keys array
@@ -121,7 +186,9 @@ const parseCertToOperation = (
   index: number,
   hash: string,
   type: string,
-  address: string
+  address: string,
+  network: number
+  // eslint-disable-next-line max-params
 ): Components.Schemas.Operation => {
   const operation: Components.Schemas.Operation = {
     operation_identifier: { index },
@@ -132,10 +199,37 @@ const parseCertToOperation = (
       staking_credential: { hex_bytes: hash, curve_type: CurveType.edwards25519 }
     }
   };
-  const delegationCert = cert.as_stake_delegation();
-  if (delegationCert) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    operation.metadata!.pool_key_hash = Buffer.from(delegationCert.pool_keyhash().to_bytes()).toString('hex');
+  if (type === OperationType.STAKE_DELEGATION) {
+    const delegationCert = cert.as_stake_delegation();
+    if (delegationCert) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      operation.metadata!.pool_key_hash = Buffer.from(delegationCert.pool_keyhash().to_bytes()).toString('hex');
+    }
+  }
+  if (type === OperationType.POOL_REGISTRATION) {
+    const poolRegistrationCert = cert.as_pool_registration();
+    if (poolRegistrationCert) {
+      operation.metadata!.pool_key_hash = Buffer.from(
+        poolRegistrationCert
+          .pool_params()
+          .operator()
+          .to_bytes()
+      ).toString('hex');
+      operation.metadata!.poolRegistrationParams = parsePoolRegistration(poolRegistrationCert, network);
+    }
+  }
+  if (type === OperationType.POOL_REGISTRATION_WITH_CERT) {
+    const poolRegistrationCert = cert.as_pool_registration();
+    if (poolRegistrationCert) {
+      operation.metadata!.pool_key_hash = Buffer.from(
+        poolRegistrationCert
+          .pool_params()
+          .operator()
+          .to_bytes()
+      ).toString('hex');
+      const parsedPoolCert = Buffer.from(poolRegistrationCert.to_bytes()).toString('hex');
+      operation.metadata!.poolRegistrationCert = parsedPoolCert;
+    }
   }
   return operation;
 };
@@ -165,7 +259,8 @@ const parseCertsToOperations = (
         stakingOperation.operation_identifier.index,
         hex,
         stakingOperation.type,
-        address
+        address,
+        network
       );
       parsedOperations.push(parsedOperation);
     }
@@ -266,13 +361,14 @@ export const convert = (
     [
       OperationType.STAKE_KEY_REGISTRATION,
       OperationType.STAKE_KEY_DEREGISTRATION,
-      OperationType.STAKE_DELEGATION
+      OperationType.STAKE_DELEGATION,
+      OperationType.POOL_REGISTRATION,
+      OperationType.POOL_REGISTRATION_WITH_CERT
     ].includes(type as OperationType)
   );
   const certsCount = transactionBody.certs()?.len() || 0;
   const parsedCertOperations = parseCertsToOperations(logger, transactionBody, stakingOps, certsCount, network);
   operations.push(...parsedCertOperations);
-
   const withdrawalOps = extraData.filter(({ type }) => type === OperationType.WITHDRAWAL);
   const withdrawalsCount = transactionBody.withdrawals()?.len() || 0;
   parseWithdrawalsToOperations(logger, withdrawalOps, withdrawalsCount, operations, network);

--- a/cardano-rosetta-server/src/server/utils/constants.ts
+++ b/cardano-rosetta-server/src/server/utils/constants.ts
@@ -44,6 +44,12 @@ export enum OperationType {
   POOL_REGISTRATION_WITH_CERT = 'poolRegistrationWithCert'
 }
 
+export enum RelayType {
+  SINGLE_HOST_ADDR = 'single_host_addr',
+  SINGLE_HOST_NAME = 'single_host_name',
+  MULTI_HOST_NAME = 'multi_host_name'
+}
+
 export const OPERATION_TYPES = Object.values(OperationType);
 
 export const StakingOperations = [
@@ -52,6 +58,8 @@ export const StakingOperations = [
   OperationType.STAKE_KEY_DEREGISTRATION,
   OperationType.WITHDRAWAL
 ];
+
+export const PoolOperations = [OperationType.POOL_REGISTRATION, OperationType.POOL_REGISTRATION_WITH_CERT];
 
 enum OperationTypeStatus {
   SUCCESS = 'success'

--- a/cardano-rosetta-server/src/server/utils/constants.ts
+++ b/cardano-rosetta-server/src/server/utils/constants.ts
@@ -39,7 +39,8 @@ export enum OperationType {
   STAKE_KEY_REGISTRATION = 'stakeKeyRegistration',
   STAKE_DELEGATION = 'stakeDelegation',
   WITHDRAWAL = 'withdrawal',
-  STAKE_KEY_DEREGISTRATION = 'stakeKeyDeregistration'
+  STAKE_KEY_DEREGISTRATION = 'stakeKeyDeregistration',
+  POOL_REGISTRATION = 'poolRegistration'
 }
 
 export const OPERATION_TYPES = Object.values(OperationType);

--- a/cardano-rosetta-server/src/server/utils/constants.ts
+++ b/cardano-rosetta-server/src/server/utils/constants.ts
@@ -78,7 +78,8 @@ export const SUCCESS_OPERATION_STATE = {
 export enum AddressType {
   ENTERPRISE = 'Enterprise',
   BASE = 'Base',
-  REWARD = 'Reward'
+  REWARD = 'Reward',
+  POOL_KEY_HASH = 'Pool_Hash'
 }
 
 export enum NetworkIdentifier {

--- a/cardano-rosetta-server/src/server/utils/constants.ts
+++ b/cardano-rosetta-server/src/server/utils/constants.ts
@@ -40,7 +40,8 @@ export enum OperationType {
   STAKE_DELEGATION = 'stakeDelegation',
   WITHDRAWAL = 'withdrawal',
   STAKE_KEY_DEREGISTRATION = 'stakeKeyDeregistration',
-  POOL_REGISTRATION = 'poolRegistration'
+  POOL_REGISTRATION = 'poolRegistration',
+  POOL_REGISTRATION_WITH_CERT = 'poolRegistrationWithCert'
 }
 
 export const OPERATION_TYPES = Object.values(OperationType);

--- a/cardano-rosetta-server/src/server/utils/data-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/data-mapper.ts
@@ -202,6 +202,31 @@ export const mapToRosettaTransaction = (transaction: PopulatedTransaction): Comp
     }
   }));
   totalOperations.push(delegationsAsOperations);
+  const poolRegistrationsAsOperations: Components.Schemas.Operation[] = transaction.poolRegistrations.map(
+    (poolRegistration, index) => ({
+      operation_identifier: {
+        index: getOperationCurrentIndex(totalOperations, index)
+      },
+      type: OperationType.POOL_REGISTRATION,
+      status: SUCCESS_STATUS,
+      account: {
+        // public cold key
+        address: poolRegistration.poolHash
+      },
+      metadata: {
+        poolRegistrationParams: {
+          pledge: poolRegistration.pledge,
+          rewardAddress: poolRegistration.address,
+          cost: poolRegistration.cost,
+          poolOwners: poolRegistration.owners,
+          margin_percentage: poolRegistration.margin,
+          vrfKeyHash: poolRegistration.vrfKeyHash,
+          relays: poolRegistration.relays
+        }
+      }
+    })
+  );
+  totalOperations.push(poolRegistrationsAsOperations);
   // Output related operations are all the inputs.This will iterate over the collection again
   // but it's better for the sake of clarity and tx are bounded by block size (it can be
   // refactored to use a reduce)

--- a/cardano-rosetta-server/src/server/utils/data-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/data-mapper.ts
@@ -20,6 +20,7 @@ import {
   MULTI_ASSET_DECIMALS,
   NetworkIdentifier,
   OperationType,
+  PoolOperations,
   SIGNATURE_TYPE,
   StakingOperations,
   SUCCESS_STATUS
@@ -433,7 +434,8 @@ export const encodeExtraData = async (
     .filter(
       operation =>
         operation.coin_change?.coin_action === COIN_SPENT_ACTION ||
-        StakingOperations.includes(operation.type as OperationType)
+        StakingOperations.includes(operation.type as OperationType) ||
+        PoolOperations.includes(operation.type as OperationType)
     );
 
   return (await cbor.encodeAsync([transaction, extraData])).toString('hex');

--- a/cardano-rosetta-server/src/server/utils/errors.ts
+++ b/cardano-rosetta-server/src/server/utils/errors.ts
@@ -1,5 +1,6 @@
 import ApiError from '../api-error';
 import ServerError from '../server-error';
+import { destination } from 'pino';
 
 export interface Error {
   message: string;
@@ -76,6 +77,12 @@ export const Errors = {
   INVALID_POOL_CERT: { message: 'Invalid pool registration certificate format', code: 4027 },
   INVALID_POOL_CERT_TYPE: { message: 'Invalid certificate type. Expected pool registration certificate', code: 4028 },
   POOL_REGISTRATION_PARAMS_MISSING: { message: 'Pool registration parameters were expected', code: 4029 },
+  INVALID_POOL_RELAYS: { message: 'Pool relays are invalid', code: 4030 },
+  INVALID_POOL_METADATA: { message: 'Pool metadata is invalid', code: 4031 },
+  DNS_NAME_MISSING: { message: 'Dns name expected for pool relay', code: 4032 },
+  INVALID_POOL_RELAY_TYPE: { message: 'Invalid pool relay type received', code: 4033 },
+  INVALID_POOL_OWNERS: { message: 'Invalid pool owners received', code: 4034 },
+  INVALID_POOL_REGISTRATION_PARAMS: { message: 'Invalid pool registration parameters received', code: 4035 },
   UNSPECIFIED_ERROR: { message: 'An error occurred', code: 5000 },
   NOT_IMPLEMENTED: { message: 'Not implemented', code: 5001 },
   ADDRESS_GENERATION_ERROR: { message: 'Address generation error', code: 5002 },
@@ -108,6 +115,7 @@ const addressGenerationError: CreateErrorFunction = () => buildApiError(Errors.A
 const invalidPublicKeyFormat: CreateErrorFunction = () => buildApiError(Errors.INVALID_PUBLIC_KEY_FORMAT, false);
 const invalidStakingKeyFormat: CreateErrorFunction = () => buildApiError(Errors.INVALID_STAKING_KEY_FORMAT, false);
 const missingStakingKeyError: CreateErrorFunction = type => buildApiError(Errors.STAKING_KEY_MISSING, false, type);
+const missingDnsNameError: CreateErrorFunction = type => buildApiError(Errors.DNS_NAME_MISSING, false, type);
 const missingPoolCertError: CreateErrorFunction = type => buildApiError(Errors.POOL_CERT_MISSING, false, type);
 const missingPoolKeyError: CreateErrorFunction = type => buildApiError(Errors.POOL_KEY_MISSING, false, type);
 const missingPoolRegistrationParameters: CreateErrorFunction = type =>
@@ -116,6 +124,16 @@ const invalidPoolRegistrationCert: CreateErrorFunction = type => buildApiError(E
 const invalidPoolRegistrationCertType: CreateErrorFunction = type =>
   buildApiError(Errors.INVALID_POOL_CERT_TYPE, false, type);
 const invalidPoolKeyError: CreateErrorFunction = details => buildApiError(Errors.INVALID_POOL_KEY_HASH, false, details);
+const invalidPoolRelaysError: CreateErrorFunction = details =>
+  buildApiError(Errors.INVALID_POOL_RELAYS, false, details);
+const invalidPoolRegistrationParameters: CreateErrorFunction = details =>
+  buildApiError(Errors.INVALID_POOL_REGISTRATION_PARAMS, false, details);
+const invalidPoolRelayTypeError: CreateErrorFunction = details =>
+  buildApiError(Errors.INVALID_POOL_RELAY_TYPE, false, details);
+const invalidPoolOwnersError: CreateErrorFunction = details =>
+  buildApiError(Errors.INVALID_POOL_OWNERS, false, details);
+const invalidPoolMetadataError: CreateErrorFunction = details =>
+  buildApiError(Errors.INVALID_POOL_METADATA, false, details);
 const parseSignedTransactionError: CreateErrorFunction = () =>
   buildApiError(Errors.PARSE_SIGNED_TRANSACTION_ERROR, false);
 const cantBuildWitnessesSet: CreateErrorFunction = () => buildApiError(Errors.CANT_BUILD_WITNESSES_SET, false);
@@ -162,11 +180,17 @@ export const ErrorFactory = {
   invalidPoolRegistrationCertType,
   invalidPublicKeyFormat,
   invalidStakingKeyFormat,
+  missingDnsNameError,
   missingStakingKeyError,
   missingPoolCertError,
   missingPoolKeyError,
   missingPoolRegistrationParameters,
   invalidPoolKeyError,
+  invalidPoolRegistrationParameters,
+  invalidPoolRelaysError,
+  invalidPoolRelayTypeError,
+  invalidPoolOwnersError,
+  invalidPoolMetadataError,
   parseSignedTransactionError,
   cantBuildSignedTransaction,
   cantBuildWitnessesSet,

--- a/cardano-rosetta-server/src/server/utils/errors.ts
+++ b/cardano-rosetta-server/src/server/utils/errors.ts
@@ -66,12 +66,16 @@ export const Errors = {
     message: 'Provided operation type is invalid',
     code: 4019
   },
-  POOL_KEY_MISSING: { message: 'Pool key hash is required for stake delegation', code: 4020 },
+  POOL_KEY_MISSING: { message: 'Pool key hash is required to operate', code: 4020 },
   TOKEN_BUNDLE_ASSETS_MISSING: { message: 'Assets are required for output operation token bundle', code: 4021 },
   TOKEN_ASSET_VALUE_MISSING: { message: 'Asset value is required for token asset', code: 4022 },
   INVALID_POLICY_ID: { message: 'Invalid policy id', code: 4023 },
   INVALID_TOKEN_NAME: { message: 'Invalid token name', code: 4024 },
   INVALID_POOL_KEY_HASH: { message: 'Provided pool key hash has invalid format', code: 4025 },
+  POOL_CERT_MISSING: { message: 'Pool registration certificate is required for pool registration', code: 4026 },
+  INVALID_POOL_CERT: { message: 'Invalid pool registration certificate format', code: 4027 },
+  INVALID_POOL_CERT_TYPE: { message: 'Invalid certificate type. Expected pool registration certificate', code: 4028 },
+  POOL_REGISTRATION_PARAMS_MISSING: { message: 'Pool registration parameters were expected', code: 4029 },
   UNSPECIFIED_ERROR: { message: 'An error occurred', code: 5000 },
   NOT_IMPLEMENTED: { message: 'Not implemented', code: 5001 },
   ADDRESS_GENERATION_ERROR: { message: 'Address generation error', code: 5002 },
@@ -104,7 +108,13 @@ const addressGenerationError: CreateErrorFunction = () => buildApiError(Errors.A
 const invalidPublicKeyFormat: CreateErrorFunction = () => buildApiError(Errors.INVALID_PUBLIC_KEY_FORMAT, false);
 const invalidStakingKeyFormat: CreateErrorFunction = () => buildApiError(Errors.INVALID_STAKING_KEY_FORMAT, false);
 const missingStakingKeyError: CreateErrorFunction = type => buildApiError(Errors.STAKING_KEY_MISSING, false, type);
+const missingPoolCertError: CreateErrorFunction = type => buildApiError(Errors.POOL_CERT_MISSING, false, type);
 const missingPoolKeyError: CreateErrorFunction = type => buildApiError(Errors.POOL_KEY_MISSING, false, type);
+const missingPoolRegistrationParameters: CreateErrorFunction = type =>
+  buildApiError(Errors.POOL_REGISTRATION_PARAMS_MISSING, false, type);
+const invalidPoolRegistrationCert: CreateErrorFunction = type => buildApiError(Errors.INVALID_POOL_CERT, false, type);
+const invalidPoolRegistrationCertType: CreateErrorFunction = type =>
+  buildApiError(Errors.INVALID_POOL_CERT_TYPE, false, type);
 const invalidPoolKeyError: CreateErrorFunction = details => buildApiError(Errors.INVALID_POOL_KEY_HASH, false, details);
 const parseSignedTransactionError: CreateErrorFunction = () =>
   buildApiError(Errors.PARSE_SIGNED_TRANSACTION_ERROR, false);
@@ -148,10 +158,14 @@ export const ErrorFactory = {
   genesisBlockNotFound,
   transactionNotFound,
   addressGenerationError,
+  invalidPoolRegistrationCert,
+  invalidPoolRegistrationCertType,
   invalidPublicKeyFormat,
   invalidStakingKeyFormat,
   missingStakingKeyError,
+  missingPoolCertError,
   missingPoolKeyError,
+  missingPoolRegistrationParameters,
   invalidPoolKeyError,
   parseSignedTransactionError,
   cantBuildSignedTransaction,

--- a/cardano-rosetta-server/src/server/utils/validations.ts
+++ b/cardano-rosetta-server/src/server/utils/validations.ts
@@ -1,6 +1,7 @@
 import { PUBLIC_KEY_BYTES_LENGTH, ADA, AddressType, CurveType, ASSET_NAME_LENGTH, POLICY_ID_LENGTH } from './constants';
 import { ErrorFactory } from './errors';
 import { isEmptyHexString } from './formatters';
+import CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
 
 const tokenNameValidation = new RegExp(`^[0-9a-fA-F]{0,${ASSET_NAME_LENGTH}}$`);
 
@@ -24,4 +25,14 @@ export const validateCurrencies = (currencies: Components.Schemas.Currency[]): v
     if (symbol !== ADA && !isPolicyIdValid(metadata.policyId))
       throw ErrorFactory.invalidPolicyIdError(`Given policy id is ${metadata.policyId}`);
   });
+};
+
+export const isEd25519KeyHash = (hash: string): boolean => {
+  let edd25519Hash: CardanoWasm.Ed25519KeyHash;
+  try {
+    edd25519Hash = CardanoWasm.Ed25519KeyHash.from_bytes(Buffer.from(hash, 'hex'));
+  } catch (error) {
+    return false;
+  }
+  return !!edd25519Hash;
 };

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -748,6 +748,10 @@ declare namespace Components {
        * A token bundle is a heterogeneous (‘mixed’) collection of tokens. Any tokens can be bundled together. Token bundles are the standard - and only - way to represent and store assets on the Cardano blockchain.
        */
       tokenBundle?: TokenBundleItem[];
+      /**
+       * Certificate of a pool registration encoded as hex string
+       */
+      poolRegistrationCert?: string;
       poolRegistrationParams?: PoolRegistrationParams;
     }
     /**

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -816,7 +816,6 @@ declare namespace Components {
        * Operational costs per epoch lovelace
        */
       cost: string;
-      rewardAccount: string;
       poolOwners: string[];
       relays: Relay[];
       poolMetadata?: PoolMetadata;
@@ -840,6 +839,7 @@ declare namespace Components {
       direction: /* Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may reference `backward` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if a transaction relation is from child to parent or the reverse. */ Direction;
     }
     export interface Relay {
+      type: string;
       ipv4?: string;
       ipv6?: string;
       dnsName?: string;

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -824,6 +824,7 @@ declare namespace Components {
       poolOwners: string[];
       relays: Relay[];
       margin?: PoolMargin;
+      margin_percentage?: string;
       poolMetadata?: PoolMetadata;
     }
     /**

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -812,6 +812,7 @@ declare namespace Components {
     }
     export interface PoolRegistrationParams {
       vrfKeyHash: string;
+      rewardAddress: string;
       /**
        * Lovelace amount to pledge
        */
@@ -844,7 +845,7 @@ declare namespace Components {
       direction: /* Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may reference `backward` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if a transaction relation is from child to parent or the reverse. */ Direction;
     }
     export interface Relay {
-      type: string;
+      type?: string;
       ipv4?: string;
       ipv6?: string;
       dnsName?: string;

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -741,7 +741,7 @@ declare namespace Components {
       /**
        * If it's a deregistration operation, the amount will re returned here.
        */
-      fundAmount?: /* Amount is some Value of a Currency. It is considered invalid to specify a Value without a Currency. */ Amount;
+      refundAmount?: /* Amount is some Value of a Currency. It is considered invalid to specify a Value without a Currency. */ Amount;
       staking_credential?: /* PublicKey contains a public key byte array for a particular CurveType encoded in hex. Note that there is no PrivateKey struct as this is NEVER the concern of an implementation. */ PublicKey;
       pool_key_hash?: string;
       /**

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -823,7 +823,7 @@ declare namespace Components {
       cost: string;
       poolOwners: string[];
       relays: Relay[];
-      margin: PoolMargin;
+      margin?: PoolMargin;
       poolMetadata?: PoolMetadata;
     }
     /**

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -802,6 +802,10 @@ declare namespace Components {
       peer_id: string;
       metadata?: {};
     }
+    export interface PoolMargin {
+      numerator: string;
+      denominator: string;
+    }
     export interface PoolMetadata {
       url: string;
       hash: string;
@@ -818,6 +822,7 @@ declare namespace Components {
       cost: string;
       poolOwners: string[];
       relays: Relay[];
+      margin: PoolMargin;
       poolMetadata?: PoolMetadata;
     }
     /**

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -748,6 +748,7 @@ declare namespace Components {
        * A token bundle is a heterogeneous (‘mixed’) collection of tokens. Any tokens can be bundled together. Token bundles are the standard - and only - way to represent and store assets on the Cardano blockchain.
        */
       tokenBundle?: TokenBundleItem[];
+      poolRegistrationParams?: PoolRegistrationParams;
     }
     /**
      * OperationStatus is utilized to indicate which Operation status are considered successful.
@@ -797,6 +798,25 @@ declare namespace Components {
       peer_id: string;
       metadata?: {};
     }
+    export interface PoolMetadata {
+      url: string;
+      hash: string;
+    }
+    export interface PoolRegistrationParams {
+      vrfKeyHash: string;
+      /**
+       * Lovelace amount to pledge
+       */
+      pledge: string;
+      /**
+       * Operational costs per epoch lovelace
+       */
+      cost: string;
+      rewardAccount: string;
+      poolOwners: string[];
+      relays: Relay[];
+      poolMetadata?: PoolMetadata;
+    }
     /**
      * PublicKey contains a public key byte array for a particular CurveType encoded in hex. Note that there is no PrivateKey struct as this is NEVER the concern of an implementation.
      */
@@ -814,6 +834,12 @@ declare namespace Components {
       network_identifier?: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
       transaction_identifier: /* The transaction_identifier uniquely identifies a transaction in a particular network and block or in the mempool. */ TransactionIdentifier;
       direction: /* Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may reference `backward` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if a transaction relation is from child to parent or the reverse. */ Direction;
+    }
+    export interface Relay {
+      ipv4?: string;
+      ipv6?: string;
+      dnsName?: string;
+      port?: string;
     }
     /**
      * SearchTransactionsRequest is used to search for transactions matching a set of provided conditions in canonical blocks.

--- a/cardano-rosetta-server/test/e2e/block/block-transactions-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/block/block-transactions-api.test.ts
@@ -10,7 +10,8 @@ import {
   transactionBlock4490558WithRegistrations,
   transactionBlock4490559WithDelegation,
   transactionBlock4597861WithWithdrawals,
-  transactionBlock4853177WithDeregistration
+  transactionBlock4853177WithDeregistration,
+  launchpad236643PoolRegistrationWithSeveralOwners
 } from '../fixture-data';
 import { setupDatabase, setupServer } from '../utils/test-utils';
 
@@ -290,5 +291,21 @@ describe('/block/transactions endpoint', () => {
 
     expect(response.statusCode).toEqual(StatusCodes.OK);
     expect(response.json()).toEqual(launchpad235546WithPoolRegistration);
+  });
+  test('should return transaction pool registrations with several owners', async () => {
+    const transaction = 'ea8e02abc93b863c386d25e31132866ddd61703f913b71d22af7d51843dd2bbe';
+    const response = await serverWithMultiassetsSupport.inject({
+      method: 'post',
+      url: BLOCK_TRANSACTION_ENDPOINT,
+      payload: {
+        ...generatePayload(279711, 'f9db8c8da4fd42fb19f7c7f8b627faf3122dc63d3bd5b85172c5141c009fc2c0'),
+        // eslint-disable-next-line camelcase
+        transaction_identifier: {
+          hash: transaction
+        }
+      }
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual(launchpad236643PoolRegistrationWithSeveralOwners);
   });
 });

--- a/cardano-rosetta-server/test/e2e/block/block-transactions-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/block/block-transactions-api.test.ts
@@ -4,6 +4,7 @@ import StatusCodes from 'http-status-codes';
 import { Pool } from 'pg';
 import {
   block23236WithTransactions,
+  launchpad235546WithPoolRegistration,
   transaction344050WithTokenBundle,
   transaction987aOnGenesis,
   transactionBlock4490558WithRegistrations,
@@ -271,5 +272,23 @@ describe('/block/transactions endpoint', () => {
     });
     expect(response.statusCode).toEqual(StatusCodes.OK);
     expect(response.json()).toEqual({ transaction: transaction344050WithTokenBundle });
+  });
+
+  test('should return transaction pool registrations', async () => {
+    const transaction = '2468895f6f8e7b00a298aab49647712ff55b453e35d14e32f737691a014c26eb';
+    const response = await serverWithMultiassetsSupport.inject({
+      method: 'post',
+      url: BLOCK_TRANSACTION_ENDPOINT,
+      payload: {
+        ...generatePayload(235546, 'beb6a8ac14ec7f51ef63f0db92ec4e7e03236f2b664b80fda568fba15191ab72'),
+        // eslint-disable-next-line camelcase
+        transaction_identifier: {
+          hash: transaction
+        }
+      }
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual(launchpad235546WithPoolRegistration);
   });
 });

--- a/cardano-rosetta-server/test/e2e/construction/construction-parse-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-parse-api.test.ts
@@ -17,6 +17,10 @@ import {
   CONSTRUCTION_PAYLOADS_STAKE_REGISTRATION_AND_WITHDRAWAL_RESPONSE,
   CONSTRUCTION_PAYLOADS_STAKE_REGISTRATION_RESPONSE,
   CONSTRUCTION_PAYLOADS_WITHDRAWAL_RESPONSE,
+  CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_AND_PLEDGE,
+  CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_CERT,
+  CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAY,
+  CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_METADATA,
   CONSTRUCTION_PAYLOADS_WITH_STAKE_DELEGATION,
   CONSTRUCTION_PAYLOADS_WITH_STAKE_KEY_DEREGISTRATION,
   CONSTRUCTION_PAYLOADS_WITH_STAKE_KEY_REGISTRATION,
@@ -29,6 +33,10 @@ import {
   CONSTRUCTION_SIGNED_TRANSACTION_WITH_MULTIPLE_MA,
   CONSTRUCTION_SIGNED_TRANSACTION_WITH_SEVERAL_MA,
   CONSTRUCTION_SIGNED_TX_WITH_MA_WITHOUT_NAME,
+  CONSTRUCTION_SIGNED_TX_WITH_POOL_REGISTRATION_AND_PLEDGE,
+  CONSTRUCTION_SIGNED_TX_WITH_POOL_REGISTRATION_WITH_CERT,
+  CONSTRUCTION_SIGNED_TX_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAYS,
+  CONSTRUCTION_SIGNED_TX_WITH_POOL_REGISTRATION_WITH_NO_METADATA,
   CONSTRUCTION_SIGNED_TX_WITH_REGISTRATION_AND_EXTRA_DATA,
   CONSTRUCTION_SIGNED_TX_WITH_REGISTRATION_AND_WITHDRWAWAL_AND_EXTRA_DATA,
   CONSTRUCTION_UNSIGNED_TRANSACTION_WITH_EXTRA_DATA
@@ -336,5 +344,71 @@ describe(CONSTRUCTION_PARSE_ENDPOINT, () => {
     expect(response.json().operations).toEqual(
       constructionParseOperations(CONSTRUCTION_PAYLOADS_REQUEST_WITM_MA_WITHOUT_NAME)
     );
+  });
+  describe('Pool registration requests', () => {
+    test('Should correctly parse operations with pool registrations with pledge ', async () => {
+      const response = await server.inject({
+        method: 'post',
+        url: CONSTRUCTION_PARSE_ENDPOINT,
+        payload: generateParsePayload(
+          'cardano',
+          'mainnet',
+          true,
+          CONSTRUCTION_SIGNED_TX_WITH_POOL_REGISTRATION_AND_PLEDGE
+        )
+      });
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      expect(response.json().operations).toEqual(
+        constructionParseOperations(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_AND_PLEDGE)
+      );
+    });
+    test('Should correctly parse operations with pool registrations with multiple relays', async () => {
+      const response = await server.inject({
+        method: 'post',
+        url: CONSTRUCTION_PARSE_ENDPOINT,
+        payload: generateParsePayload(
+          'cardano',
+          'mainnet',
+          true,
+          CONSTRUCTION_SIGNED_TX_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAYS
+        )
+      });
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      expect(response.json().operations).toEqual(
+        constructionParseOperations(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAY)
+      );
+    });
+    test('Should correctly parse operations with pool registrations with no pool metadata', async () => {
+      const response = await server.inject({
+        method: 'post',
+        url: CONSTRUCTION_PARSE_ENDPOINT,
+        payload: generateParsePayload(
+          'cardano',
+          'mainnet',
+          true,
+          CONSTRUCTION_SIGNED_TX_WITH_POOL_REGISTRATION_WITH_NO_METADATA
+        )
+      });
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      expect(response.json().operations).toEqual(
+        constructionParseOperations(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_METADATA)
+      );
+    });
+    test('Should correctly parse operations with pool registrations with cert', async () => {
+      const response = await server.inject({
+        method: 'post',
+        url: CONSTRUCTION_PARSE_ENDPOINT,
+        payload: generateParsePayload(
+          'cardano',
+          'mainnet',
+          true,
+          CONSTRUCTION_SIGNED_TX_WITH_POOL_REGISTRATION_WITH_CERT
+        )
+      });
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      expect(response.json().operations).toEqual(
+        constructionParseOperations(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_CERT)
+      );
+    });
   });
 });

--- a/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
@@ -1427,6 +1427,39 @@ describe('Pool Registration', () => {
       retriable: false
     });
   });
+
+  test('Should throw an error when there are operations including pool registration with no margin', async () => {
+    const invalidPoolRelays = {
+      vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+      rewardAddress: 'e1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb',
+      pledge: '5000000',
+      cost: '3000000',
+      poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
+      relays: [{ type: 'single_host_addr', dnsName: 'dnsName', port: '2020' }],
+      poolMetadata: {
+        url: 'poolMetadataUrl',
+        hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
+      }
+    };
+    const payload = modfyPoolParameters(
+      CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_METADATA,
+      invalidPoolRelays
+    );
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_PAYLOADS_ENDPOINT,
+      payload
+    });
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({
+      code: 4035,
+      message: 'Invalid pool registration parameters received',
+      details: {
+        message: 'Missing margin parameter at pool registration parameters'
+      },
+      retriable: false
+    });
+  });
   test('Should throw an error when there are operations including pool registration with invalid reward address', async () => {
     const payloadWithInvalidAddress = {
       vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',

--- a/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
@@ -1044,6 +1044,10 @@ describe('Pool Registration', () => {
       cost: '3000000',
       poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
       relays: [],
+      margin: {
+        numerator: '1',
+        denominator: '1'
+      },
       poolMetadata: {
         url: 'poolMetadataUrl',
         hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
@@ -1070,6 +1074,10 @@ describe('Pool Registration', () => {
       cost: '3000000',
       poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
       relays: [{ type: 'invalidType' }],
+      margin: {
+        numerator: '1',
+        denominator: '1'
+      },
       poolMetadata: {
         url: 'poolMetadataUrl',
         hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
@@ -1099,6 +1107,10 @@ describe('Pool Registration', () => {
       cost: '3000000',
       poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
       relays: [{ type: 'single_host_addr', ipv4: 'notAHexString' }],
+      margin: {
+        numerator: '1',
+        denominator: '1'
+      },
       poolMetadata: {
         url: 'poolMetadataUrl',
         hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
@@ -1128,6 +1140,10 @@ describe('Pool Registration', () => {
       cost: '3000000',
       poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
       relays: [{ type: 'single_host_name', dnsName: 'dnsName', port: 'NaN' }],
+      margin: {
+        numerator: '1',
+        denominator: '1'
+      },
       poolMetadata: {
         url: 'poolMetadataUrl',
         hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
@@ -1160,6 +1176,10 @@ describe('Pool Registration', () => {
       cost: '3000000',
       poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
       relays: [{ type: 'single_host_addr', dnsName: 'dnsName', port: '2020' }],
+      margin: {
+        numerator: '1',
+        denominator: '1'
+      },
       poolMetadata: {
         url: 'poolMetadataUrl',
         hash: invalidMetadataHash
@@ -1193,6 +1213,10 @@ describe('Pool Registration', () => {
       cost: '3000000',
       poolOwners: [invalidPoolOwner],
       relays: [{ type: 'single_host_addr', dnsName: 'dnsName', port: '2020' }],
+      margin: {
+        numerator: '1',
+        denominator: '1'
+      },
       poolMetadata: {
         url: 'poolMetadataUrl',
         hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
@@ -1225,6 +1249,10 @@ describe('Pool Registration', () => {
       cost: '-3000000',
       poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
       relays: [{ type: 'single_host_addr', dnsName: 'dnsName', port: '2020' }],
+      margin: {
+        numerator: '1',
+        denominator: '1'
+      },
       poolMetadata: {
         url: 'poolMetadataUrl',
         hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
@@ -1244,7 +1272,7 @@ describe('Pool Registration', () => {
       code: 4035,
       message: 'Invalid pool registration parameters received',
       details: {
-        message: 'Given pool cost -3000000 is invalid'
+        message: 'Given cost -3000000 is invalid'
       },
       retriable: false
     });
@@ -1256,6 +1284,10 @@ describe('Pool Registration', () => {
       cost: '3000000',
       poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
       relays: [{ type: 'single_host_addr', dnsName: 'dnsName', port: '2020' }],
+      margin: {
+        numerator: '1',
+        denominator: '1'
+      },
       poolMetadata: {
         url: 'poolMetadataUrl',
         hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
@@ -1275,7 +1307,77 @@ describe('Pool Registration', () => {
       code: 4035,
       message: 'Invalid pool registration parameters received',
       details: {
-        message: 'Given pool pledge -5000000 is invalid'
+        message: 'Given pledge -5000000 is invalid'
+      },
+      retriable: false
+    });
+  });
+  test('Should throw an error when there are operations including pool registration with pool relays with negative denominator', async () => {
+    const invalidPoolRelays = {
+      vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+      pledge: '5000000',
+      cost: '3000000',
+      poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
+      relays: [{ type: 'single_host_addr', dnsName: 'dnsName', port: '2020' }],
+      margin: {
+        numerator: '1',
+        denominator: '-1'
+      },
+      poolMetadata: {
+        url: 'poolMetadataUrl',
+        hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
+      }
+    };
+    const payload = modfyPoolParameters(
+      CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_METADATA,
+      invalidPoolRelays
+    );
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_PAYLOADS_ENDPOINT,
+      payload
+    });
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({
+      code: 4035,
+      message: 'Invalid pool registration parameters received',
+      details: {
+        message: 'Given denominator -1 is invalid'
+      },
+      retriable: false
+    });
+  });
+  test('Should throw an error when there are operations including pool registration with pool relays with alphabetical numerator', async () => {
+    const invalidPoolRelays = {
+      vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+      pledge: '5000000',
+      cost: '3000000',
+      poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
+      relays: [{ type: 'single_host_addr', dnsName: 'dnsName', port: '2020' }],
+      margin: {
+        numerator: '1asad',
+        denominator: '1'
+      },
+      poolMetadata: {
+        url: 'poolMetadataUrl',
+        hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
+      }
+    };
+    const payload = modfyPoolParameters(
+      CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_METADATA,
+      invalidPoolRelays
+    );
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_PAYLOADS_ENDPOINT,
+      payload
+    });
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({
+      code: 4035,
+      message: 'Invalid pool registration parameters received',
+      details: {
+        message: 'ParseIntError { kind: InvalidDigit }'
       },
       retriable: false
     });

--- a/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
@@ -599,7 +599,7 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
     expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
     expect(response.json()).toEqual({
       code: 4020,
-      message: 'Pool key hash is required for stake delegation',
+      message: 'Pool key hash is required to operate',
       retriable: false
     });
   });

--- a/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
@@ -13,6 +13,13 @@ import {
   CONSTRUCTION_PAYLOADS_REQUEST_WITH_MA,
   CONSTRUCTION_PAYLOADS_REQUEST_WITH_MULTIPLE_MA,
   CONSTRUCTION_PAYLOADS_REQUEST_WITM_MA_WITHOUT_NAME,
+  CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_AND_PLEDGE,
+  CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_CERT,
+  CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTI_HOST_NAME,
+  CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAY,
+  CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_METADATA,
+  CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_ADDR,
+  CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_NAME,
   CONSTRUCTION_PAYLOADS_WITH_STAKE_DELEGATION,
   CONSTRUCTION_PAYLOADS_WITH_STAKE_KEY_DEREGISTRATION,
   CONSTRUCTION_PAYLOADS_WITH_STAKE_KEY_REGISTRATION,
@@ -24,6 +31,13 @@ import {
   SIGNED_TX_WITH_MA,
   SIGNED_TX_WITH_MA_WITHOUT_NAME,
   SIGNED_TX_WITH_MULTIPLE_MA,
+  SIGNED_TX_WITH_POOL_REGISTRATION_AND_PLEDGE,
+  SIGNED_TX_WITH_POOL_REGISTRATION_WITH_CERT,
+  SIGNED_TX_WITH_POOL_REGISTRATION_WITH_MULTI_HOST_NAME,
+  SIGNED_TX_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAYS,
+  SIGNED_TX_WITH_POOL_REGISTRATION_WITH_NO_METADATA,
+  SIGNED_TX_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_ADDR,
+  SIGNED_TX_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_NAME,
   SIGNED_TX_WITH_STAKE_DELEGATION,
   SIGNED_TX_WITH_STAKE_KEY_DEREGISTRATION,
   SIGNED_TX_WITH_STAKE_KEY_REGISTRATION,
@@ -638,6 +652,145 @@ describe(CONSTRUCTION_PREPROCESS_ENDPOINT, () => {
         },
         message: invalidOperationErrorMessage,
         retriable: false
+      });
+    });
+  });
+  describe('Pool registration requests', () => {
+    test('Should properly process transactions with pool registrations with pledge', async () => {
+      const response = await server.inject({
+        method: 'post',
+        url: CONSTRUCTION_PREPROCESS_ENDPOINT,
+        // eslint-disable-next-line no-magic-numbers
+        payload: generateProcessPayload({
+          blockchain: 'cardano',
+          network: 'mainnet',
+          relativeTtl: 100,
+          operations: CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_AND_PLEDGE.operations
+        })
+      });
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      expect(response.json()).toEqual({
+        options: { relative_ttl: 100, transaction_size: sizeInBytes(SIGNED_TX_WITH_POOL_REGISTRATION_AND_PLEDGE) }
+      });
+    });
+    test('Should properly process transactions with pool registrations with multiple relays', async () => {
+      const response = await server.inject({
+        method: 'post',
+        url: CONSTRUCTION_PREPROCESS_ENDPOINT,
+        // eslint-disable-next-line no-magic-numbers
+        payload: generateProcessPayload({
+          blockchain: 'cardano',
+          network: 'mainnet',
+          relativeTtl: 100,
+          operations: CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAY.operations
+        })
+      });
+
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      expect(response.json()).toEqual({
+        options: {
+          relative_ttl: 100,
+          transaction_size: sizeInBytes(SIGNED_TX_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAYS)
+        }
+      });
+    });
+    test('Should properly process transactions with pool registrations with single host addr', async () => {
+      const response = await server.inject({
+        method: 'post',
+        url: CONSTRUCTION_PREPROCESS_ENDPOINT,
+        // eslint-disable-next-line no-magic-numbers
+        payload: generateProcessPayload({
+          blockchain: 'cardano',
+          network: 'mainnet',
+          relativeTtl: 100,
+          operations: CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_ADDR.operations
+        })
+      });
+
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      expect(response.json()).toEqual({
+        options: {
+          relative_ttl: 100,
+          transaction_size: sizeInBytes(SIGNED_TX_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_ADDR)
+        }
+      });
+    });
+    test('Should properly process transactions with pool registrations with single host name', async () => {
+      const response = await server.inject({
+        method: 'post',
+        url: CONSTRUCTION_PREPROCESS_ENDPOINT,
+        // eslint-disable-next-line no-magic-numbers
+        payload: generateProcessPayload({
+          blockchain: 'cardano',
+          network: 'mainnet',
+          relativeTtl: 100,
+          operations: CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_NAME.operations
+        })
+      });
+
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      expect(response.json()).toEqual({
+        options: {
+          relative_ttl: 100,
+          transaction_size: sizeInBytes(SIGNED_TX_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_NAME)
+        }
+      });
+    });
+    test('Should properly process transactions with pool registrations with multiple host name', async () => {
+      const response = await server.inject({
+        method: 'post',
+        url: CONSTRUCTION_PREPROCESS_ENDPOINT,
+        // eslint-disable-next-line no-magic-numbers
+        payload: generateProcessPayload({
+          blockchain: 'cardano',
+          network: 'mainnet',
+          relativeTtl: 100,
+          operations: CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTI_HOST_NAME.operations
+        })
+      });
+
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      expect(response.json()).toEqual({
+        options: {
+          relative_ttl: 100,
+          transaction_size: sizeInBytes(SIGNED_TX_WITH_POOL_REGISTRATION_WITH_MULTI_HOST_NAME)
+        }
+      });
+    });
+    test('Should properly process transactions with pool registrations with no pool metadata', async () => {
+      const response = await server.inject({
+        method: 'post',
+        url: CONSTRUCTION_PREPROCESS_ENDPOINT,
+        // eslint-disable-next-line no-magic-numbers
+        payload: generateProcessPayload({
+          blockchain: 'cardano',
+          network: 'mainnet',
+          relativeTtl: 100,
+          operations: CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_METADATA.operations
+        })
+      });
+
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      expect(response.json()).toEqual({
+        options: { relative_ttl: 100, transaction_size: sizeInBytes(SIGNED_TX_WITH_POOL_REGISTRATION_WITH_NO_METADATA) }
+      });
+    });
+    test('Should properly process transactions with pool registrations with cert', async () => {
+      const response = await server.inject({
+        method: 'post',
+        url: CONSTRUCTION_PREPROCESS_ENDPOINT,
+        // eslint-disable-next-line no-magic-numbers
+        payload: generateProcessPayload({
+          blockchain: 'cardano',
+          network: 'mainnet',
+          relativeTtl: 100,
+          operations: CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_CERT.operations
+        })
+      });
+
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      expect(response.json()).toEqual({
+        options: { relative_ttl: 100, transaction_size: sizeInBytes(SIGNED_TX_WITH_POOL_REGISTRATION_WITH_CERT) }
       });
     });
   });

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -646,6 +646,80 @@ export const transactionBlock4853177WithDeregistration = {
   }
 };
 
+export const launchpad235546WithPoolRegistration = {
+  transaction: {
+    operations: [
+      {
+        operation_identifier: { index: 0 },
+        type: 'input',
+        status: 'success',
+        account: {
+          address:
+            'addr_test1qrgej788jgwwqg2dnufrkeeksykjtu86trqlcd82585jgey2zanrjjggmm0t38fdgannesv9z9q2en42qar2t6rsat3q9yh4ug'
+        },
+        amount: { value: '-799997817691', currency: { symbol: 'ADA', decimals: 6 } },
+        coin_change: {
+          coin_identifier: {
+            identifier: 'd2e592ab44f65f8335dee7640a956d17a21f9020006253c52a939f3ba0fd3398:0'
+          },
+          coin_action: 'coin_spent'
+        }
+      },
+      {
+        operation_identifier: { index: 1 },
+        type: 'stakeDelegation',
+        status: 'success',
+        account: { address: 'stake_test1uz9pwe3efyydah4cn5k5weeucxz3zs9ve64qw349apcw4csdllxv4' },
+        metadata: { pool_key_hash: '503c82138b10d84b0ba36ff2e7342ea7fc40c57498dbc6fafe0cd322' }
+      },
+      {
+        operation_identifier: { index: 2 },
+        type: 'poolRegistration',
+        status: 'success',
+        account: { address: '503c82138b10d84b0ba36ff2e7342ea7fc40c57498dbc6fafe0cd322' },
+        metadata: {
+          poolRegistrationParams: {
+            rewardAddress: 'e08a1766394908dedeb89d2d47673cc1851140acceaa0746a5e870eae2',
+            cost: '340000000',
+            margin_percentage: '0.08',
+            pledge: '799450000000',
+            poolOwners: ['8a1766394908dedeb89d2d47673cc1851140acceaa0746a5e870eae2'],
+            relays: [
+              {
+                dnsName: 'relays.cardano-launchpad.chaincrucial.io',
+                ipv4: '',
+                ipv6: '',
+                port: '23001'
+              }
+            ],
+            vrfKeyHash: '74511e297e8d8670729af5a4eb08ff8b49f0247f1100f28ce5599b44f07b57b4'
+          }
+        }
+      },
+      {
+        operation_identifier: { index: 3, network_index: 0 },
+        related_operations: [{ index: 0 }],
+        type: 'output',
+        status: 'success',
+        account: {
+          address:
+            'addr_test1qrgej788jgwwqg2dnufrkeeksykjtu86trqlcd82585jgey2zanrjjggmm0t38fdgannesv9z9q2en42qar2t6rsat3q9yh4ug'
+        },
+        amount: { value: '799497619058', currency: { symbol: 'ADA', decimals: 6 } },
+        coin_change: {
+          coin_identifier: {
+            identifier: '2468895f6f8e7b00a298aab49647712ff55b453e35d14e32f737691a014c26eb:0'
+          },
+          coin_action: 'coin_created'
+        }
+      }
+    ],
+    transaction_identifier: {
+      hash: '2468895f6f8e7b00a298aab49647712ff55b453e35d14e32f737691a014c26eb'
+    }
+  }
+};
+
 export const transaction344050WithTokenBundle = {
   operations: [
     {

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -620,7 +620,7 @@ export const transactionBlock4853177WithDeregistration = {
         type: 'stakeKeyDeregistration',
         status: 'success',
         account: { address: 'stake1u8zfnkhp4g6vhneetmv2qen7f5ndrklqjq8e9s2nck9h30cfz6qmp' },
-        metadata: { fundAmount: { value: '-2000000', currency: { symbol: 'ADA', decimals: 6 } } }
+        metadata: { refundAmount: { value: '-2000000', currency: { symbol: 'ADA', decimals: 6 } } }
       },
       {
         operation_identifier: { index: 2, network_index: 0 },
@@ -678,6 +678,13 @@ export const launchpad235546WithPoolRegistration = {
         status: 'success',
         account: { address: '503c82138b10d84b0ba36ff2e7342ea7fc40c57498dbc6fafe0cd322' },
         metadata: {
+          depositAmount: {
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            },
+            value: '500000000'
+          },
           poolRegistrationParams: {
             rewardAddress: 'e08a1766394908dedeb89d2d47673cc1851140acceaa0746a5e870eae2',
             cost: '340000000',

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -727,6 +727,82 @@ export const launchpad235546WithPoolRegistration = {
   }
 };
 
+export const launchpad236643PoolRegistrationWithSeveralOwners = {
+  transaction: {
+    operations: [
+      {
+        operation_identifier: { index: 0 },
+        type: 'input',
+        status: 'success',
+        account: {
+          address:
+            'addr_test1qqslw59gg528x70pa3vg0ynsdfx70kr70erug22h5tkkvj3eppr5tp2u2uddxy6lq0pq2yjxttpnja6z84s5pp2xvqtsytzc8e'
+        },
+        amount: { value: '-2166859938552', currency: { symbol: 'ADA', decimals: 6 } },
+        coin_change: {
+          coin_identifier: {
+            identifier: 'e785c4ddb544decdc304bcd5110c6f92463d35029e0124de3e706399b6537e00:0'
+          },
+          coin_action: 'coin_spent'
+        }
+      },
+      {
+        operation_identifier: { index: 1 },
+        type: 'poolRegistration',
+        status: 'success',
+        account: { address: 'd6aafa5358b98373449434542e3da3564bc71635ae3247dc1a2b7b0e' },
+        metadata: {
+          depositAmount: { value: '500000000', currency: { symbol: 'ADA', decimals: 6 } },
+          poolRegistrationParams: {
+            rewardAddress: 'e0f695c35024868c4dd6f694e16b88bdf6986e31a074f790d75241c44b',
+            cost: '10000000000',
+            margin_percentage: '0.1',
+            pledge: '100000000',
+            poolOwners: [
+              '03d205532089ad2f7816892e2ef42849b7b52788e41b3fd43a6e01cf',
+              'c13582aec9a44fcc6d984be003c5058c660e1d2ff1370fd8b49ba73f',
+              'f695c35024868c4dd6f694e16b88bdf6986e31a074f790d75241c44b'
+            ],
+            relays: [
+              {
+                dnsName: '',
+                ipv4: '127.0.0.1',
+                ipv6: '',
+                port: '3001'
+              }
+            ],
+            vrfKeyHash: 'c78992878b9af2bff8363a3c45b0ead3b9a2ee6eb6e611e731037bb25b4db9ae'
+          }
+        }
+      },
+      {
+        operation_identifier: { index: 2, network_index: 0 },
+        related_operations: [
+          {
+            index: 0
+          }
+        ],
+        type: 'output',
+        status: 'success',
+        account: {
+          address:
+            'addr_test1qqslw59gg528x70pa3vg0ynsdfx70kr70erug22h5tkkvj3eppr5tp2u2uddxy6lq0pq2yjxttpnja6z84s5pp2xvqtsytzc8e'
+        },
+        amount: { value: '2166859729095', currency: { symbol: 'ADA', decimals: 6 } },
+        coin_change: {
+          coin_identifier: {
+            identifier: 'ea8e02abc93b863c386d25e31132866ddd61703f913b71d22af7d51843dd2bbe:0'
+          },
+          coin_action: 'coin_created'
+        }
+      }
+    ],
+    transaction_identifier: {
+      hash: 'ea8e02abc93b863c386d25e31132866ddd61703f913b71d22af7d51843dd2bbe'
+    }
+  }
+};
+
 export const transaction344050WithTokenBundle = {
   operations: [
     {

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -2612,6 +2612,10 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_AND_PLEDGE: Components
               port: '32'
             }
           ],
+          margin: {
+            numerator: '1',
+            denominator: '1'
+          },
           poolMetadata: {
             url: 'poolMetadataUrl',
             hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
@@ -2750,6 +2754,10 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAY: C
               dnsName: 'dnsName'
             }
           ],
+          margin: {
+            numerator: '1',
+            denominator: '1'
+          },
           poolMetadata: {
             url: 'poolMetadataUrl',
             hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
@@ -2880,6 +2888,10 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_ADDR:
               port: '32'
             }
           ],
+          margin: {
+            numerator: '1',
+            denominator: '1'
+          },
           poolMetadata: {
             url: 'poolMetadataUrl',
             hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
@@ -2993,7 +3005,11 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_METADATA: Comp
               ipv6: '505820f5d9ea167fd2e0b19647f18dd1e0',
               port: '32'
             }
-          ]
+          ],
+          margin: {
+            numerator: '1',
+            denominator: '1'
+          }
         }
       }
     }
@@ -3103,6 +3119,10 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_NAME:
               port: '32'
             }
           ],
+          margin: {
+            numerator: '1',
+            denominator: '1'
+          },
           poolMetadata: {
             url: 'poolMetadataUrl',
             hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
@@ -3215,6 +3235,10 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTI_HOST_NAME: 
               dnsName: 'dnsName'
             }
           ],
+          margin: {
+            numerator: '1',
+            denominator: '1'
+          },
           poolMetadata: {
             url: 'poolMetadataUrl',
             hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -1,8 +1,9 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable unicorn/prevent-abbreviations */
 /* eslint-disable max-len */
 /* eslint-disable no-magic-numbers */
 import cbor from 'cbor';
-import { OperationType, SIGNATURE_TYPE, StakingOperations } from '../../src/server/utils/constants';
+import { OperationType, SIGNATURE_TYPE, StakingOperations, PoolOperations } from '../../src/server/utils/constants';
 
 /* eslint-disable camelcase */
 const slotLeader2b1 = 'ByronGenesis-52df0f2c5539b2b1';
@@ -2510,6 +2511,1031 @@ export const CONSTRUCTION_PAYLOADS_WITH_STAKE_KEY_REGISTRATION_AND_WITHDRAWAL: C
   }
 };
 
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_AND_PLEDGE: Components.Schemas.ConstructionPayloadsRequest = {
+  network_identifier: {
+    blockchain: 'cardano',
+    network: 'mainnet'
+  },
+  operations: [
+    {
+      operation_identifier: {
+        index: 0,
+        network_index: 0
+      },
+      type: OperationType.INPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '-90000000000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      },
+      coin_change: {
+        coin_identifier: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          identifier: '2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1'
+        },
+        coin_action: 'coin_spent'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 1
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '10000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 2
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '40000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      type: OperationType.POOL_REGISTRATION,
+      status: 'success',
+      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      metadata: {
+        staking_credential: {
+          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
+          curve_type: 'edwards25519'
+        },
+        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
+        poolRegistrationParams: {
+          vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+          pledge: '5000000',
+          cost: '3000000',
+          poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
+          relays: [
+            {
+              type: 'single_host_addr',
+              ipv4: '445820f5d9',
+              ipv6: '505820f5d9ea167fd2e0b19647f18dd1e0',
+              port: '32'
+            }
+          ],
+          poolMetadata: {
+            url: 'poolMetadataUrl',
+            hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
+          }
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      type: OperationType.STAKE_DELEGATION,
+      status: 'success',
+      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      metadata: {
+        staking_credential: {
+          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
+          curve_type: 'edwards25519'
+        },
+        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5'
+      }
+    }
+  ],
+  metadata: {
+    ttl: '1000'
+  }
+};
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAY: Components.Schemas.ConstructionPayloadsRequest = {
+  network_identifier: {
+    blockchain: 'cardano',
+    network: 'mainnet'
+  },
+  operations: [
+    {
+      operation_identifier: {
+        index: 0,
+        network_index: 0
+      },
+      type: OperationType.INPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '-90000000000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      },
+      coin_change: {
+        coin_identifier: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          identifier: '2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1'
+        },
+        coin_action: 'coin_spent'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 1
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '10000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 2
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '40000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      type: OperationType.POOL_REGISTRATION,
+      status: 'success',
+      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      metadata: {
+        staking_credential: {
+          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
+          curve_type: 'edwards25519'
+        },
+        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
+        poolRegistrationParams: {
+          vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+          pledge: '5000000',
+          cost: '3000000',
+          poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
+          relays: [
+            {
+              type: 'single_host_addr',
+              ipv4: '445820f5d9',
+              ipv6: '505820f5d9ea167fd2e0b19647f18dd1e0',
+              port: '32'
+            },
+            {
+              type: 'single_host_name',
+              dnsName: 'dnsName',
+              port: '32'
+            },
+            {
+              type: 'multi_host_name',
+              dnsName: 'dnsName'
+            }
+          ],
+          poolMetadata: {
+            url: 'poolMetadataUrl',
+            hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
+          }
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      type: OperationType.STAKE_DELEGATION,
+      status: 'success',
+      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      metadata: {
+        staking_credential: {
+          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
+          curve_type: 'edwards25519'
+        },
+        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5'
+      }
+    }
+  ],
+  metadata: {
+    ttl: '1000'
+  }
+};
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_ADDR: Components.Schemas.ConstructionPayloadsRequest = {
+  network_identifier: {
+    blockchain: 'cardano',
+    network: 'mainnet'
+  },
+  operations: [
+    {
+      operation_identifier: {
+        index: 0,
+        network_index: 0
+      },
+      type: OperationType.INPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '-90000000000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      },
+      coin_change: {
+        coin_identifier: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          identifier: '2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1'
+        },
+        coin_action: 'coin_spent'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 1
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '10000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 2
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '40000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      type: OperationType.POOL_REGISTRATION,
+      status: 'success',
+      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      metadata: {
+        staking_credential: {
+          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
+          curve_type: 'edwards25519'
+        },
+        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
+        poolRegistrationParams: {
+          vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+          pledge: '0',
+          cost: '3000000',
+          poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
+          relays: [
+            {
+              type: 'single_host_addr',
+              ipv4: '445820f5d9',
+              ipv6: '505820f5d9ea167fd2e0b19647f18dd1e0',
+              dnsName: 'dnsName',
+              port: '32'
+            }
+          ],
+          poolMetadata: {
+            url: 'poolMetadataUrl',
+            hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
+          }
+        }
+      }
+    }
+  ],
+  metadata: {
+    ttl: '1000'
+  }
+};
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_METADATA: Components.Schemas.ConstructionPayloadsRequest = {
+  network_identifier: {
+    blockchain: 'cardano',
+    network: 'mainnet'
+  },
+  operations: [
+    {
+      operation_identifier: {
+        index: 0,
+        network_index: 0
+      },
+      type: OperationType.INPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '-90000000000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      },
+      coin_change: {
+        coin_identifier: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          identifier: '2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1'
+        },
+        coin_action: 'coin_spent'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 1
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '10000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 2
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '40000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      type: OperationType.POOL_REGISTRATION,
+      status: 'success',
+      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      metadata: {
+        staking_credential: {
+          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
+          curve_type: 'edwards25519'
+        },
+        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
+        poolRegistrationParams: {
+          vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+          pledge: '0',
+          cost: '3000000',
+          poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
+          relays: [
+            {
+              type: 'single_host_addr',
+              ipv4: '445820f5d9',
+              ipv6: '505820f5d9ea167fd2e0b19647f18dd1e0',
+              port: '32'
+            }
+          ]
+        }
+      }
+    }
+  ],
+  metadata: {
+    ttl: '1000'
+  }
+};
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_NAME: Components.Schemas.ConstructionPayloadsRequest = {
+  network_identifier: {
+    blockchain: 'cardano',
+    network: 'mainnet'
+  },
+  operations: [
+    {
+      operation_identifier: {
+        index: 0,
+        network_index: 0
+      },
+      type: OperationType.INPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '-90000000000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      },
+      coin_change: {
+        coin_identifier: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          identifier: '2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1'
+        },
+        coin_action: 'coin_spent'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 1
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '10000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 2
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '40000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      type: OperationType.POOL_REGISTRATION,
+      status: 'success',
+      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      metadata: {
+        staking_credential: {
+          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
+          curve_type: 'edwards25519'
+        },
+        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
+        poolRegistrationParams: {
+          vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+          pledge: '0',
+          cost: '3000000',
+          poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
+          relays: [
+            {
+              type: 'single_host_addr',
+              dnsName: 'dnsName',
+              port: '32'
+            }
+          ],
+          poolMetadata: {
+            url: 'poolMetadataUrl',
+            hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
+          }
+        }
+      }
+    }
+  ],
+  metadata: {
+    ttl: '1000'
+  }
+};
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTI_HOST_NAME: Components.Schemas.ConstructionPayloadsRequest = {
+  network_identifier: {
+    blockchain: 'cardano',
+    network: 'mainnet'
+  },
+  operations: [
+    {
+      operation_identifier: {
+        index: 0,
+        network_index: 0
+      },
+      type: OperationType.INPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '-90000000000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      },
+      coin_change: {
+        coin_identifier: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          identifier: '2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1'
+        },
+        coin_action: 'coin_spent'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 1
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '10000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 2
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '40000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      type: OperationType.POOL_REGISTRATION,
+      status: 'success',
+      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      metadata: {
+        staking_credential: {
+          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
+          curve_type: 'edwards25519'
+        },
+        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
+        poolRegistrationParams: {
+          vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+          pledge: '0',
+          cost: '3000000',
+          poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
+          relays: [
+            {
+              type: 'multi_host_name',
+              dnsName: 'dnsName'
+            }
+          ],
+          poolMetadata: {
+            url: 'poolMetadataUrl',
+            hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
+          }
+        }
+      }
+    }
+  ],
+  metadata: {
+    ttl: '1000'
+  }
+};
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_CERT: Components.Schemas.ConstructionPayloadsRequest = {
+  network_identifier: {
+    blockchain: 'cardano',
+    network: 'mainnet'
+  },
+  operations: [
+    {
+      operation_identifier: {
+        index: 0,
+        network_index: 0
+      },
+      type: OperationType.INPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '-90000000000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      },
+      coin_change: {
+        coin_identifier: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          identifier: '2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1'
+        },
+        coin_action: 'coin_spent'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 1
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '10000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 2
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '40000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      type: OperationType.POOL_REGISTRATION_WITH_CERT,
+      status: 'success',
+      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      metadata: {
+        staking_credential: {
+          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
+          curve_type: 'edwards25519'
+        },
+        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
+        poolRegistrationCert:
+          '8a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db01a004c4b401a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008184001820445820f5d9505820f5d9ea167fd2e0b19647f18dd1e0826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      type: OperationType.STAKE_DELEGATION,
+      status: 'success',
+      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      metadata: {
+        staking_credential: {
+          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
+          curve_type: 'edwards25519'
+        },
+        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5'
+      }
+    }
+  ],
+  metadata: {
+    ttl: '1000'
+  }
+};
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_INVALID_CERT: Components.Schemas.ConstructionPayloadsRequest = {
+  network_identifier: {
+    blockchain: 'cardano',
+    network: 'mainnet'
+  },
+  operations: [
+    {
+      operation_identifier: {
+        index: 0,
+        network_index: 0
+      },
+      type: OperationType.INPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '-9000000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      },
+      coin_change: {
+        coin_identifier: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          identifier: '2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1'
+        },
+        coin_action: 'coin_spent'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 1
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '10000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 2
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '40000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      type: OperationType.POOL_REGISTRATION_WITH_CERT,
+      status: 'success',
+      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      metadata: {
+        staking_credential: {
+          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
+          curve_type: 'edwards25519'
+        },
+        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
+        poolRegistrationCert: 'notAValidHexCert'
+      }
+    }
+  ],
+  metadata: {
+    ttl: '1000'
+  }
+};
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_INVALID_CERT_TYPE: Components.Schemas.ConstructionPayloadsRequest = {
+  network_identifier: {
+    blockchain: 'cardano',
+    network: 'mainnet'
+  },
+  operations: [
+    {
+      operation_identifier: {
+        index: 0,
+        network_index: 0
+      },
+      type: OperationType.INPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '-9000000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      },
+      coin_change: {
+        coin_identifier: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          identifier: '2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1'
+        },
+        coin_action: 'coin_spent'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 1
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '10000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 2
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '40000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      type: OperationType.POOL_REGISTRATION_WITH_CERT,
+      status: 'success',
+      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      metadata: {
+        staking_credential: {
+          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
+          curve_type: 'edwards25519'
+        },
+        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
+        poolRegistrationCert:
+          '83028200581cbb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5'
+      }
+    }
+  ],
+  metadata: {
+    ttl: '1000'
+  }
+};
+
 export const CONSTRUCTION_PAYLOADS_INVALID_OPERATION_TYPE: Components.Schemas.ConstructionPayloadsRequest = {
   network_identifier: {
     blockchain: 'cardano',
@@ -2650,7 +3676,10 @@ export const CONSTRUCTION_PAYLOADS_MULTIPLE_INPUTS: Components.Schemas.Construct
 
 const constructionExtraData = (constructionPayloadsRequest: Components.Schemas.ConstructionPayloadsRequest) =>
   constructionPayloadsRequest.operations.filter(
-    op => op.coin_change?.coin_action === 'coin_spent' || StakingOperations.includes(op.type as OperationType)
+    op =>
+      op.coin_change?.coin_action === 'coin_spent' ||
+      StakingOperations.includes(op.type as OperationType) ||
+      PoolOperations.includes(op.type as OperationType)
   );
 
 export const CONSTRUCTION_PAYLOADS_RESPONSE = cbor
@@ -2706,6 +3735,55 @@ export const CONSTRUCTION_PAYLOADS_STAKE_REGISTRATION_AND_WITHDRAWAL_RESPONSE = 
   .encode([
     'a600818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021a006a3380031903e8048182008200581cbb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb05a1581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb192710',
     constructionExtraData(CONSTRUCTION_PAYLOADS_WITH_STAKE_KEY_REGISTRATION_AND_WITHDRAWAL)
+  ])
+  .toString('hex');
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_AND_PLEDGE_RESPONSE = cbor
+  .encode([
+    'a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0031903e804828a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db01a004c4b401a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008184001820445820f5d9505820f5d9ea167fd2e0b19647f18dd1e0826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b83028200581cbb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
+    constructionExtraData(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_AND_PLEDGE)
+  ])
+  .toString('hex');
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_ADDR_RESPONSE = cbor
+  .encode([
+    'a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0031903e804818a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0001a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008184001820445820f5d9505820f5d9ea167fd2e0b19647f18dd1e0826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b',
+    constructionExtraData(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_ADDR)
+  ])
+  .toString('hex');
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_NAME_RESPONSE = cbor
+  .encode([
+    'a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0031903e804818a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0001a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008184001820f6f6826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b',
+    constructionExtraData(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_NAME)
+  ])
+  .toString('hex');
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_METADATA_RESPONSE = cbor
+  .encode([
+    'a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0031903e804818a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0001a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008184001820445820f5d9505820f5d9ea167fd2e0b19647f18dd1e0f6',
+    constructionExtraData(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_METADATA)
+  ])
+  .toString('hex');
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTI_HOST_NAME_RESPONSE = cbor
+  .encode([
+    'a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0031903e804818a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0001a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f0081820267646e734e616d65826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b',
+    constructionExtraData(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTI_HOST_NAME)
+  ])
+  .toString('hex');
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAY_RESPONSE = cbor
+  .encode([
+    'a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0031903e804828a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db01a004c4b401a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008384001820445820f5d9505820f5d9ea167fd2e0b19647f18dd1e08301182067646e734e616d65820267646e734e616d65826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b83028200581cbb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
+    constructionExtraData(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAY)
+  ])
+  .toString('hex');
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_CERT_RESPONSE = cbor
+  .encode([
+    'a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0031903e804828a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db01a004c4b401a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008184001820445820f5d9505820f5d9ea167fd2e0b19647f18dd1e0826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b83028200581cbb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
+    constructionExtraData(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_CERT)
   ])
   .toString('hex');
 
@@ -3048,6 +4126,27 @@ export const SIGNED_TX_WITH_TWO_WITHDRAWALS =
 export const SIGNED_TX_WITH_STAKE_KEY_REGISTRATION_AND_WITHDRWAWAL =
   '83a600818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021a006a33800300048182008200581cbb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb05a1581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb192710a1008282582000000000000000000000000000000000000000000000000000000000000000005840000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008258200000000000000000000000000000000000000000000000000000000000000000584000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f6';
 
+export const SIGNED_TX_WITH_POOL_REGISTRATION_AND_PLEDGE =
+  '83a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0030004828a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db01a004c4b401a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008184001820445820f5d9505820f5d9ea167fd2e0b19647f18dd1e0826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b83028200581cbb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5a10083825820000000000000000000000000000000000000000000000000000000000000000058400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000005840000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008258200000000000000000000000000000000000000000000000000000000000000000584000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f6';
+
+export const SIGNED_TX_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAYS =
+  '83a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0030004828a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db01a004c4b401a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008384001820445820f5d9505820f5d9ea167fd2e0b19647f18dd1e08301182067646e734e616d65820267646e734e616d65826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b83028200581cbb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5a10083825820000000000000000000000000000000000000000000000000000000000000000058400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000005840000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008258200000000000000000000000000000000000000000000000000000000000000000584000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f6';
+
+export const SIGNED_TX_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_ADDR =
+  '83a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0030004818a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0001a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008184001820445820f5d9505820f5d9ea167fd2e0b19647f18dd1e0826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90ba1008282582000000000000000000000000000000000000000000000000000000000000000005840000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008258200000000000000000000000000000000000000000000000000000000000000000584000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f6';
+
+export const SIGNED_TX_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_NAME =
+  '83a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0030004818a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0001a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008184001820f6f6826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90ba1008282582000000000000000000000000000000000000000000000000000000000000000005840000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008258200000000000000000000000000000000000000000000000000000000000000000584000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f6';
+
+export const SIGNED_TX_WITH_POOL_REGISTRATION_WITH_MULTI_HOST_NAME =
+  '83a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0030004818a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0001a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f0081820267646e734e616d65826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90ba1008282582000000000000000000000000000000000000000000000000000000000000000005840000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008258200000000000000000000000000000000000000000000000000000000000000000584000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f6';
+
+export const SIGNED_TX_WITH_POOL_REGISTRATION_WITH_NO_METADATA =
+  '83a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0030004818a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0001a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008184001820445820f5d9505820f5d9ea167fd2e0b19647f18dd1e0f6a1008282582000000000000000000000000000000000000000000000000000000000000000005840000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008258200000000000000000000000000000000000000000000000000000000000000000584000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f6';
+
+export const SIGNED_TX_WITH_POOL_REGISTRATION_WITH_CERT =
+  '83a500818258202f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f01018282581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb19271082581d61bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb199c40021b00000014d69cdbb0030004828a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db01a004c4b401a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008184001820445820f5d9505820f5d9ea167fd2e0b19647f18dd1e0826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b83028200581cbb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5a10083825820000000000000000000000000000000000000000000000000000000000000000058400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000005840000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008258200000000000000000000000000000000000000000000000000000000000000000584000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f6';
+
 export const CONSTRUCTION_SIGNED_TRANSACTION_WITH_MA = cbor
   .encode([SIGNED_TX_WITH_MA, constructionExtraData(CONSTRUCTION_PAYLOADS_REQUEST_WITH_MA)])
   .toString('hex');
@@ -3066,6 +4165,34 @@ export const CONSTRUCTION_SIGNED_TRANSACTION_WITH_SEVERAL_MA = cbor
 
 export const CONSTRUCTION_SIGNED_TRANSACTION_WITH_EXTRA_DATA = cbor
   .encode([SIGNED_TRANSACTION, constructionExtraData(CONSTRUCTION_PAYLOADS_REQUEST)])
+  .toString('hex');
+
+export const CONSTRUCTION_SIGNED_TX_WITH_POOL_REGISTRATION_AND_PLEDGE = cbor
+  .encode([
+    SIGNED_TX_WITH_POOL_REGISTRATION_AND_PLEDGE,
+    constructionExtraData(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_AND_PLEDGE)
+  ])
+  .toString('hex');
+
+export const CONSTRUCTION_SIGNED_TX_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAYS = cbor
+  .encode([
+    SIGNED_TX_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAYS,
+    constructionExtraData(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAY)
+  ])
+  .toString('hex');
+
+export const CONSTRUCTION_SIGNED_TX_WITH_POOL_REGISTRATION_WITH_NO_METADATA = cbor
+  .encode([
+    SIGNED_TX_WITH_POOL_REGISTRATION_WITH_NO_METADATA,
+    constructionExtraData(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_METADATA)
+  ])
+  .toString('hex');
+
+export const CONSTRUCTION_SIGNED_TX_WITH_POOL_REGISTRATION_WITH_CERT = cbor
+  .encode([
+    SIGNED_TX_WITH_POOL_REGISTRATION_WITH_CERT,
+    constructionExtraData(CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_CERT)
+  ])
   .toString('hex');
 
 export const CONSTRUCTION_SIGNED_TX_WITH_BYRON_ADDRESS_AND_EXTRA_DATA = cbor

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -2592,15 +2592,11 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_AND_PLEDGE: Components
       },
       type: OperationType.POOL_REGISTRATION,
       status: 'success',
-      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      account: { address: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5' },
       metadata: {
-        staking_credential: {
-          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
-          curve_type: 'edwards25519'
-        },
-        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
         poolRegistrationParams: {
           vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+          rewardAddress: 'e1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb',
           pledge: '5000000',
           cost: '3000000',
           poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
@@ -2725,15 +2721,11 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTIPLE_RELAY: C
       },
       type: OperationType.POOL_REGISTRATION,
       status: 'success',
-      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      account: { address: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5' },
       metadata: {
-        staking_credential: {
-          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
-          curve_type: 'edwards25519'
-        },
-        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
         poolRegistrationParams: {
           vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+          rewardAddress: 'e1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb',
           pledge: '5000000',
           cost: '3000000',
           poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
@@ -2867,15 +2859,11 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_ADDR:
       },
       type: OperationType.POOL_REGISTRATION,
       status: 'success',
-      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      account: { address: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5' },
       metadata: {
-        staking_credential: {
-          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
-          curve_type: 'edwards25519'
-        },
-        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
         poolRegistrationParams: {
           vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+          rewardAddress: 'e1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb',
           pledge: '0',
           cost: '3000000',
           poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
@@ -2986,15 +2974,11 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_METADATA: Comp
       },
       type: OperationType.POOL_REGISTRATION,
       status: 'success',
-      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      account: { address: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5' },
       metadata: {
-        staking_credential: {
-          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
-          curve_type: 'edwards25519'
-        },
-        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
         poolRegistrationParams: {
           vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+          rewardAddress: 'e1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb',
           pledge: '0',
           cost: '3000000',
           poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
@@ -3100,15 +3084,11 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_SINGLE_HOST_NAME:
       },
       type: OperationType.POOL_REGISTRATION,
       status: 'success',
-      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      account: { address: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5' },
       metadata: {
-        staking_credential: {
-          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
-          curve_type: 'edwards25519'
-        },
-        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
         poolRegistrationParams: {
           vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+          rewardAddress: 'e1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb',
           pledge: '0',
           cost: '3000000',
           poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
@@ -3217,15 +3197,11 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTI_HOST_NAME: 
       },
       type: OperationType.POOL_REGISTRATION,
       status: 'success',
-      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      account: { address: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5' },
       metadata: {
-        staking_credential: {
-          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
-          curve_type: 'edwards25519'
-        },
-        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
         poolRegistrationParams: {
           vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+          rewardAddress: 'e1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb',
           pledge: '0',
           cost: '3000000',
           poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
@@ -3242,6 +3218,115 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_MULTI_HOST_NAME: 
           poolMetadata: {
             url: 'poolMetadataUrl',
             hash: '9ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
+          }
+        }
+      }
+    }
+  ],
+  metadata: {
+    ttl: '1000'
+  }
+};
+
+export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_NO_COLD_KEY: Components.Schemas.ConstructionPayloadsRequest = {
+  network_identifier: {
+    blockchain: 'cardano',
+    network: 'mainnet'
+  },
+  operations: [
+    {
+      operation_identifier: {
+        index: 0,
+        network_index: 0
+      },
+      type: OperationType.INPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '-90000000000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      },
+      coin_change: {
+        coin_identifier: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          identifier: '2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1'
+        },
+        coin_action: 'coin_spent'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 1
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '10000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 2
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '40000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 3
+      },
+      type: OperationType.POOL_REGISTRATION,
+      status: 'success',
+      metadata: {
+        poolRegistrationParams: {
+          vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0',
+          rewardAddress: 'e1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb',
+          pledge: '0',
+          cost: '3000000',
+          poolOwners: ['7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f00'],
+          relays: [
+            {
+              type: 'single_host_addr',
+              ipv4: '445820f5d9',
+              ipv6: '505820f5d9ea167fd2e0b19647f18dd1e0',
+              port: '32'
+            }
+          ],
+          margin: {
+            numerator: '1',
+            denominator: '1'
           }
         }
       }
@@ -3333,13 +3418,8 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_CERT: Components.
       },
       type: OperationType.POOL_REGISTRATION_WITH_CERT,
       status: 'success',
-      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      account: { address: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5' },
       metadata: {
-        staking_credential: {
-          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
-          curve_type: 'edwards25519'
-        },
-        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
         poolRegistrationCert:
           '8a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db01a004c4b401a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008184001820445820f5d9505820f5d9ea167fd2e0b19647f18dd1e0826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b'
       }
@@ -3446,13 +3526,8 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_INVALID_CERT: Com
       },
       type: OperationType.POOL_REGISTRATION_WITH_CERT,
       status: 'success',
-      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      account: { address: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5' },
       metadata: {
-        staking_credential: {
-          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
-          curve_type: 'edwards25519'
-        },
-        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
         poolRegistrationCert: 'notAValidHexCert'
       }
     }
@@ -3543,13 +3618,8 @@ export const CONSTRUCTION_PAYLOADS_WITH_POOL_REGISTRATION_WITH_INVALID_CERT_TYPE
       },
       type: OperationType.POOL_REGISTRATION_WITH_CERT,
       status: 'success',
-      account: { address: 'stake1uxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7caek7a5' },
+      account: { address: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5' },
       metadata: {
-        staking_credential: {
-          hex_bytes: '1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F',
-          curve_type: 'edwards25519'
-        },
-        pool_key_hash: '1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5',
         poolRegistrationCert:
           '83028200581cbb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5'
       }

--- a/cardano-rosetta-server/test/e2e/jest-setup/docker.ts
+++ b/cardano-rosetta-server/test/e2e/jest-setup/docker.ts
@@ -7,10 +7,10 @@ const CONTAINER_TEMP_DIR = '/tmp';
 const CONTAINER_NAME = 'cardano-test';
 
 export const removePostgresContainer = async (): Promise<void> => {
-  const docker = new Docker();
-  const container = await docker.getContainer(CONTAINER_NAME);
-  await container.stop();
-  await container.remove({ v: true });
+  // const docker = new Docker();
+  // const container = await docker.getContainer(CONTAINER_NAME);
+  // await container.stop();
+  // await container.remove({ v: true });
 };
 
 interface DatabaseConfig {

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -131,6 +131,24 @@ const allow = {
       message: 'Pool registration parameters were expected',
       retriable: false
     },
+    { code: 4030, message: 'Pool relays are invalid', retriable: false },
+    { code: 4031, message: 'Pool metadata is invalid', retriable: false },
+    { code: 4032, message: 'Dns name expected for pool relay', retriable: false },
+    {
+      code: 4033,
+      message: 'Invalid pool relay type received',
+      retriable: false
+    },
+    {
+      code: 4034,
+      message: 'Invalid pool owners received',
+      retriable: false
+    },
+    {
+      code: 4035,
+      message: 'Invalid pool registration parameters received',
+      retriable: false
+    },
     {
       code: 5000,
       message: 'An error occurred',

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -91,7 +91,7 @@ const allow = {
     },
     {
       code: 4020,
-      message: 'Pool key hash is required for stake delegation',
+      message: 'Pool key hash is required to operate',
       retriable: false
     },
     {
@@ -109,6 +109,26 @@ const allow = {
     {
       code: 4025,
       message: 'Provided pool key hash has invalid format',
+      retriable: false
+    },
+    {
+      code: 4026,
+      message: 'Pool registration certificate is required for pool registration',
+      retriable: false
+    },
+    {
+      code: 4027,
+      message: 'Invalid pool registration certificate format',
+      retriable: false
+    },
+    {
+      code: 4028,
+      message: 'Invalid certificate type. Expected pool registration certificate',
+      retriable: false
+    },
+    {
+      code: 4029,
+      message: 'Pool registration parameters were expected',
       retriable: false
     },
     {

--- a/cardano-rosetta-server/test/e2e/utils/test-utils.ts
+++ b/cardano-rosetta-server/test/e2e/utils/test-utils.ts
@@ -46,11 +46,12 @@ export const cardanoNodeMock: CardanoNode = {
     'cardano-node 1.18.0 - linux-x86_64 - ghc-8.6\ngit rev 36ad7b90bfbde8afd41b68ed9b928df3fcab0dbc'
 };
 
-export const linearFeeParameters = { minFeeA: 44, minFeeB: 155381 };
-
-const NETWORK_ID = 'mainnet';
 export const minKeyDeposit = 2000000;
 export const poolDeposit = 500000000;
+
+export const linearFeeParameters = { minFeeA: 44, minFeeB: 155381 };
+export const depositsParameters = { keyDeposit: minKeyDeposit, poolDeposit };
+const NETWORK_ID = 'mainnet';
 
 export const setupServer = (database: Pool): FastifyInstance => {
   // let repositories;
@@ -63,8 +64,7 @@ export const setupServer = (database: Pool): FastifyInstance => {
     JSON.parse(fs.readFileSync(path.resolve(process.env.TOPOLOGY_FILE_PATH)).toString()),
     Number(process.env.DEFAULT_RELATIVE_TTL),
     linearFeeParameters,
-    minKeyDeposit,
-    poolDeposit
+    depositsParameters
   );
   return buildServer(services, cardanoCliMock, cardanoNodeMock, process.env.LOGGER_LEVEL, {
     networkId: NETWORK_ID,

--- a/cardano-rosetta-server/test/e2e/utils/test-utils.ts
+++ b/cardano-rosetta-server/test/e2e/utils/test-utils.ts
@@ -50,6 +50,7 @@ export const linearFeeParameters = { minFeeA: 44, minFeeB: 155381 };
 
 const NETWORK_ID = 'mainnet';
 export const minKeyDeposit = 2000000;
+export const poolDeposit = 500000000;
 
 export const setupServer = (database: Pool): FastifyInstance => {
   // let repositories;
@@ -62,7 +63,8 @@ export const setupServer = (database: Pool): FastifyInstance => {
     JSON.parse(fs.readFileSync(path.resolve(process.env.TOPOLOGY_FILE_PATH)).toString()),
     Number(process.env.DEFAULT_RELATIVE_TTL),
     linearFeeParameters,
-    minKeyDeposit
+    minKeyDeposit,
+    poolDeposit
   );
   return buildServer(services, cardanoCliMock, cardanoNodeMock, process.env.LOGGER_LEVEL, {
     networkId: NETWORK_ID,

--- a/cardano-rosetta-server/test/e2e/utils/test-utils.ts
+++ b/cardano-rosetta-server/test/e2e/utils/test-utils.ts
@@ -132,11 +132,25 @@ export const modifyCoinChange = (
 
 export const modifyPoolKeyHash = (
   payload: Components.Schemas.ConstructionPayloadsRequest,
+  operationType: OperationType,
   poolKeyHash?: string
 ): Components.Schemas.ConstructionPayloadsRequest =>
   mod(
     'operations',
-    findBy((operation: Components.Schemas.Operation) => operation && operation.type === OperationType.STAKE_DELEGATION),
+    findBy((operation: Components.Schemas.Operation) => operation && operation.type === operationType),
     'metadata',
     'pool_key_hash'
   )(() => poolKeyHash)(payload);
+
+export const modfyPoolParameters = (
+  payload: Components.Schemas.ConstructionPayloadsRequest,
+  poolParameters: Components.Schemas.PoolRegistrationParams
+): Components.Schemas.ConstructionPayloadsRequest =>
+  mod(
+    'operations',
+    findBy(
+      (operation: Components.Schemas.Operation) => operation && operation.type === OperationType.POOL_REGISTRATION
+    ),
+    'metadata',
+    'poolRegistrationParams'
+  )(() => poolParameters)(payload);

--- a/cardano-rosetta-server/test/e2e/utils/test-utils.ts
+++ b/cardano-rosetta-server/test/e2e/utils/test-utils.ts
@@ -154,3 +154,14 @@ export const modfyPoolParameters = (
     'metadata',
     'poolRegistrationParams'
   )(() => poolParameters)(payload);
+
+export const modifyAccount = (
+  payload: Components.Schemas.ConstructionPayloadsRequest,
+  accountIdentifier: Components.Schemas.AccountIdentifier,
+  operationType: OperationType
+): Components.Schemas.ConstructionPayloadsRequest =>
+  mod(
+    'operations',
+    findBy((operation: Components.Schemas.Operation) => operation && operation.type === operationType),
+    'account'
+  )(() => accountIdentifier)(payload);

--- a/cardano-rosetta-server/test/unit/services/cardano-services.test.ts
+++ b/cardano-rosetta-server/test/unit/services/cardano-services.test.ts
@@ -1,12 +1,13 @@
 import configure, { CardanoService } from '../../../src/server/services/cardano-services';
 import { EraAddressType } from '../../../src/server/utils/constants';
 const minKeyDeposit = 2000000;
+export const poolDeposit = 500000000;
 
 describe('Cardano Service', () => {
   let cardanoService: CardanoService;
 
   beforeAll(() => {
-    cardanoService = configure({ minFeeA: 0, minFeeB: 0 }, minKeyDeposit);
+    cardanoService = configure({ minFeeA: 0, minFeeB: 0 }, minKeyDeposit, poolDeposit);
   });
 
   describe('Address type detection', () => {

--- a/cardano-rosetta-server/test/unit/services/cardano-services.test.ts
+++ b/cardano-rosetta-server/test/unit/services/cardano-services.test.ts
@@ -1,13 +1,13 @@
 import configure, { CardanoService } from '../../../src/server/services/cardano-services';
 import { EraAddressType } from '../../../src/server/utils/constants';
 const minKeyDeposit = 2000000;
-export const poolDeposit = 500000000;
+const poolDeposit = 500000000;
 
 describe('Cardano Service', () => {
   let cardanoService: CardanoService;
 
   beforeAll(() => {
-    cardanoService = configure({ minFeeA: 0, minFeeB: 0 }, minKeyDeposit, poolDeposit);
+    cardanoService = configure({ minFeeA: 0, minFeeB: 0 }, { keyDeposit: minKeyDeposit, poolDeposit });
   });
 
   describe('Address type detection', () => {


### PR DESCRIPTION
# Description

Adds support for pool registration operations at `/block` endpoint.

# Proposed Solution

Since a pool registration operation can be composed of multiple owners and relays, three queries were created to bring pool's owners, relays, and other data.
A new field in `OperationMetadata` named `margin_percentage` was added in order to show pool margin. The deposit amount shown is read from the protocol parameters.

# Testing

New test cases to cover this kind of operation were introduced

# References

Depends on #344. Closes #339.
