### PR TITLE
feat: pool retirement operation in block transaction endpoints

### DIFF
--- a/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
+++ b/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
@@ -279,6 +279,12 @@ export interface FindMaBalance {
   value: string;
 }
 
+export interface FindPoolRetirements extends FindTransactionFieldResult {
+  address: Buffer;
+  poolKeyHash: Buffer;
+  epoch: number;
+}
+
 const poolRegistrationQuery = `
   WITH pool_registration AS (
   SELECT
@@ -358,6 +364,19 @@ WITH utxo AS (
 	  tx_in_tx.id IS NULL
 )`;
 
+const findPoolRetirements = `
+SELECT 
+  pr.retiring_epoch AS "epoch",
+  ph.hash_raw AS "address",
+  tx.hash as "txHash"
+FROM pool_retire pr 
+INNER JOIN pool_hash ph 
+  ON pr.hash_id = ph.id
+INNER JOIN tx
+  ON tx.id = pr.announced_tx_id
+WHERE tx.hash = ANY($1)
+`;
+
 const findUtxoByAddressAndBlock = (currencies?: CurrencyId[]): string => `
   ${utxoQuery}
   SELECT
@@ -432,6 +451,7 @@ const Queries = {
   findTransactionWithdrawals,
   findTransactionsByBlock,
   findTransactionsInputs,
+  findPoolRetirements,
   findTransactionsOutputs,
   findUtxoByAddressAndBlock,
   findLatestMinFeeAAndMinFeeB

--- a/cardano-rosetta-server/src/server/models.ts
+++ b/cardano-rosetta-server/src/server/models.ts
@@ -120,6 +120,11 @@ export interface PoolRegistration {
   metadataHash?: string;
 }
 
+export interface PoolRetirement {
+  epoch: number;
+  address: string;
+}
+
 export interface Delegation {
   stakeAddress: string;
   poolHash: string;
@@ -140,6 +145,7 @@ export interface PopulatedTransaction extends Transaction {
   deregistrations: Deregistration[];
   delegations: Delegation[];
   poolRegistrations: PoolRegistration[];
+  poolRetirements: PoolRetirement[];
 }
 
 export interface Network {

--- a/cardano-rosetta-server/src/server/utils/data-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/data-mapper.ts
@@ -175,6 +175,24 @@ export const mapToRosettaTransaction = (
     })
   );
   totalOperations.push(registrationsAsOperations);
+  const poolRetirementOperations: Components.Schemas.Operation[] = transaction.poolRetirements.map(
+    (poolRetirement, index) => ({
+      operation_identifier: {
+        index: getOperationCurrentIndex(totalOperations, index)
+      },
+      type: OperationType.POOL_RETIREMENT,
+      status: SUCCESS_STATUS,
+      account: {
+        address: poolRetirement.address
+      },
+      metadata: {
+        epoch: poolRetirement.epoch,
+        refundAmount: mapAmount((poolDeposit * -1).toString())
+      }
+    })
+  );
+  totalOperations.push(poolRetirementOperations);
+
   const deregistrationsAsOperations: Components.Schemas.Operation[] = transaction.deregistrations.map(
     (deregistration, index) => ({
       operation_identifier: {

--- a/cardano-rosetta-server/test/e2e/block/block-transactions-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/block/block-transactions-api.test.ts
@@ -11,6 +11,7 @@ import {
   transactionBlock4490559WithDelegation,
   transactionBlock4597861WithWithdrawals,
   transactionBlock4853177WithDeregistration,
+  transactionBlock4853177WithPoolRetirement,
   launchpad236643PoolRegistrationWithSeveralOwners
 } from '../fixture-data';
 import { setupDatabase, setupServer } from '../utils/test-utils';
@@ -256,6 +257,23 @@ describe('/block/transactions endpoint', () => {
     });
     expect(response.statusCode).toEqual(StatusCodes.OK);
     expect(response.json()).toEqual(transactionBlock4853177WithDeregistration);
+  });
+
+  test('should return a pool retirement transaction', async () => {
+    const transaction = 'dcbff41c50c5b4012d49be5be75b11a0c5289515258ef4cf108eb6ec4ed5f37a';
+    const response = await serverWithMultiassetsSupport.inject({
+      method: 'post',
+      url: BLOCK_TRANSACTION_ENDPOINT,
+      payload: {
+        ...generatePayload(236746, 'b389d1c4975563bf4199afeaa1434dfd1b406e30ac4eda884a03ecef8cd0a87a'),
+        // eslint-disable-next-line camelcase
+        transaction_identifier: {
+          hash: transaction
+        }
+      }
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual(transactionBlock4853177WithPoolRetirement);
   });
 
   test('should be able to return multiasset token transactions with several tokens in the bundle', async () => {

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -596,6 +596,139 @@ export const transactionBlock4490559WithDelegation = {
   }
 };
 
+export const transactionBlock4853177WithPoolRetirement = {
+  transaction: {
+    transaction_identifier: {
+      hash: 'dcbff41c50c5b4012d49be5be75b11a0c5289515258ef4cf108eb6ec4ed5f37a'
+    },
+    operations: [
+      {
+        operation_identifier: { index: 0 },
+        type: 'input',
+        status: 'success',
+        account: {
+          address:
+            'addr_test1qzyh0zdfjmk997fkdrgcm4xmuhcqqd4qgphkmgm3shryrjhkjhp4qfyx33xada55u94c300knphrrgr577gdw5jpc39srpfmlp'
+        },
+        amount: { value: '-269377901300', currency: { symbol: 'ADA', decimals: 6 } },
+        coin_change: {
+          coin_identifier: {
+            identifier: '30ca1269e56ed17c97c202164c14e31a58c104f60927ed5de4252255fc624b6b:0'
+          },
+          coin_action: 'coin_spent'
+        },
+        metadata: {
+          tokenBundle: [
+            {
+              policyId: '202e0181ea963e2fcd206b1a794ce160afbe120dad5fd30a181d3a24',
+              tokens: [
+                {
+                  value: '-1000000000000',
+                  currency: { symbol: '41434c', decimals: 0 }
+                }
+              ]
+            },
+            {
+              policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518',
+              tokens: [
+                {
+                  value: '-9952',
+                  currency: { symbol: '4154414441636f696e', decimals: 0 }
+                },
+                {
+                  value: '-8000000000',
+                  currency: { symbol: '61646f736961', decimals: 0 }
+                },
+                {
+                  value: '-2500',
+                  currency: { symbol: '6d616368746c636f696e', decimals: 0 }
+                }
+              ]
+            },
+            {
+              policyId: 'ecd07b4ef62f37a68d145de8efd60c53d288dd5ffc641215120cc3db',
+              tokens: [
+                {
+                  value: '-500',
+                  currency: { symbol: '6d616368746c32636f696e', decimals: 0 }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        operation_identifier: { index: 1 },
+        type: 'poolRetirement',
+        status: 'success',
+        account: {
+          address: 'd6aafa5358b98373449434542e3da3564bc71635ae3247dc1a2b7b0e'
+        },
+        metadata: {
+          epoch: 676,
+          refundAmount: { value: '-500000000', currency: { symbol: 'ADA', decimals: 6 } }
+        }
+      },
+      {
+        operation_identifier: { index: 2, network_index: 0 },
+        related_operations: [{ index: 0 }],
+        type: 'output',
+        status: 'success',
+        account: {
+          address:
+            'addr_test1qzyh0zdfjmk997fkdrgcm4xmuhcqqd4qgphkmgm3shryrjhkjhp4qfyx33xada55u94c300knphrrgr577gdw5jpc39srpfmlp'
+        },
+        amount: { value: '269377714987', currency: { symbol: 'ADA', decimals: 6 } },
+        coin_change: {
+          coin_identifier: {
+            identifier: 'dcbff41c50c5b4012d49be5be75b11a0c5289515258ef4cf108eb6ec4ed5f37a:0'
+          },
+          coin_action: 'coin_created'
+        },
+        metadata: {
+          tokenBundle: [
+            {
+              policyId: '202e0181ea963e2fcd206b1a794ce160afbe120dad5fd30a181d3a24',
+              tokens: [
+                {
+                  value: '1000000000000',
+                  currency: { symbol: '41434c', decimals: 0 }
+                }
+              ]
+            },
+            {
+              policyId: '34250edd1e9836f5378702fbf9416b709bc140e04f668cc355208518',
+              tokens: [
+                {
+                  value: '9952',
+                  currency: { symbol: '4154414441636f696e', decimals: 0 }
+                },
+                {
+                  value: '8000000000',
+                  currency: { symbol: '61646f736961', decimals: 0 }
+                },
+                {
+                  value: '2500',
+                  currency: { symbol: '6d616368746c636f696e', decimals: 0 }
+                }
+              ]
+            },
+            {
+              policyId: 'ecd07b4ef62f37a68d145de8efd60c53d288dd5ffc641215120cc3db',
+              tokens: [
+                {
+                  value: '500',
+                  currency: { symbol: '6d616368746c32636f696e', decimals: 0 }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+};
+
 export const transactionBlock4853177WithDeregistration = {
   transaction: {
     operations: [


### PR DESCRIPTION
# Description

Adds support for pool retirements at **data api**.

# Proposed Solution

A new type of operation was added called **operation retirement* in a previous branch. This branch consist in return these kind of operations in the block transaction queried.

# Testing

New tests were introduced in order to cover new test cases introduced.

# References

Closes data api issue descripted at #342 
