### PR TITLE
Catch OutsideValidityIntervalUTxO node error in construction controller

### DIFF
--- a/cardano-rosetta-server/src/server/controllers/construction-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/construction-controller.ts
@@ -16,9 +16,7 @@ import { NetworkService } from '../services/network-service';
 import { AddressType } from '../utils/constants';
 import { isAddressTypeValid, isKeyValid } from '../utils/validations';
 import { BlockService } from '../services/block-service';
-import { appendFile } from 'fs';
 import ApiError from '../api-error';
-import { map } from 'shades';
 
 export interface ConstructionController {
   constructionDerive(

--- a/cardano-rosetta-server/src/server/controllers/construction-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/construction-controller.ts
@@ -9,13 +9,16 @@ import {
   mapAmount,
   mapToConstructionHashResponse
 } from '../utils/data-mapper';
-import { ErrorFactory } from '../utils/errors';
+import { ErrorFactory, ErrorUtils } from '../utils/errors';
 import { withNetworkValidation } from './controllers-helper';
 import { CardanoCli } from '../utils/cardano/cli/cardanonode-cli';
 import { NetworkService } from '../services/network-service';
 import { AddressType } from '../utils/constants';
 import { isAddressTypeValid, isKeyValid } from '../utils/validations';
 import { BlockService } from '../services/block-service';
+import { appendFile } from 'fs';
+import ApiError from '../api-error';
+import { map } from 'shades';
 
 export interface ConstructionController {
   constructionDerive(
@@ -50,8 +53,6 @@ export interface ConstructionController {
     request: FastifyRequest<unknown, unknown, unknown, unknown, Components.Schemas.ConstructionSubmitRequest>
   ): Promise<Components.Schemas.TransactionIdentifierResponse | Components.Schemas.Error>;
 }
-
-const OUTSIDE_VALIDITY_UTXO = new RegExp('OutsideValidityIntervalUTxO');
 
 const configure = (
   constructionService: ConstructionService,
@@ -281,10 +282,9 @@ const configure = (
           return { transaction_identifier: { hash: transactionHash } };
         } catch (error) {
           request.log.error(error);
-          if (OUTSIDE_VALIDITY_UTXO.test(error.message)) {
-            return ErrorFactory.sendOutsideValidityIntervalUtxoError(error.message);
-          }
-          return ErrorFactory.sendTransactionError(error.message);
+          return ErrorUtils.resolveApiErrorFromNodeError(error.message)
+            .then((mappedError: ApiError) => mappedError)
+            .catch(() => ErrorFactory.sendTransactionError(error.message));
         }
       },
       request.log,

--- a/cardano-rosetta-server/src/server/controllers/construction-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/construction-controller.ts
@@ -51,6 +51,8 @@ export interface ConstructionController {
   ): Promise<Components.Schemas.TransactionIdentifierResponse | Components.Schemas.Error>;
 }
 
+const OUTSIDE_VALIDITY_UTXO = new RegExp('OutsideValidityIntervalUTxO');
+
 const configure = (
   constructionService: ConstructionService,
   cardanoService: CardanoService,
@@ -279,6 +281,9 @@ const configure = (
           return { transaction_identifier: { hash: transactionHash } };
         } catch (error) {
           request.log.error(error);
+          if (OUTSIDE_VALIDITY_UTXO.test(error.message)) {
+            return ErrorFactory.sendOutsideValidityIntervalUtxoError(error.message);
+          }
           return ErrorFactory.sendTransactionError(error.message);
         }
       },

--- a/cardano-rosetta-server/src/server/utils/errors.ts
+++ b/cardano-rosetta-server/src/server/utils/errors.ts
@@ -227,3 +227,37 @@ export const ErrorFactory = {
 
 export const configNotFoundError: CreateServerErrorFunction = () =>
   new ServerError('Environment configurations needed to run server were not found');
+
+export type nodeOutputToError = {
+  error: Error;
+  inputPattern: RegExp;
+  retriable: boolean;
+};
+
+const nodeErrorToRosettaErrorMap: Array<nodeOutputToError> = [
+  {
+    error: Errors.OUTSIDE_VALIDITY_INTERVAL_UTXO,
+    inputPattern: new RegExp('OutsideValidityIntervalUTxO'),
+    retriable: false
+  }
+];
+
+const resolveApiErrorFromNodeSourced = (
+  nodeErrorMessage: string,
+  errorMappings: nodeOutputToError[]
+): Promise<ApiError> => {
+  const found: nodeOutputToError[] = errorMappings.filter(error => error.inputPattern.test(nodeErrorMessage));
+  if (found.length > 0) {
+    const error = found[0].error;
+    return Promise.resolve(new ApiError(error.code, error.message, found[0].retriable));
+  }
+  return Promise.reject('error not found');
+};
+
+const resolveApiErrorFromNodeError = (nodeErrorMessage: string): Promise<ApiError> =>
+  resolveApiErrorFromNodeSourced(nodeErrorMessage, nodeErrorToRosettaErrorMap);
+
+export const ErrorUtils = {
+  resolveApiErrorFromNodeSourced,
+  resolveApiErrorFromNodeError
+};

--- a/cardano-rosetta-server/src/server/utils/errors.ts
+++ b/cardano-rosetta-server/src/server/utils/errors.ts
@@ -87,6 +87,10 @@ export const Errors = {
     message: 'Mandatory parameter is missing: Epoch',
     code: 4036
   },
+  OUTSIDE_VALIDITY_INTERVAL_UTXO: {
+    message: 'Error when sending the transaction - OutsideValidityIntervalUTxO',
+    code: 4037
+  },
   UNSPECIFIED_ERROR: { message: 'An error occurred', code: 5000 },
   NOT_IMPLEMENTED: { message: 'Not implemented', code: 5001 },
   ADDRESS_GENERATION_ERROR: { message: 'Address generation error', code: 5002 },
@@ -171,6 +175,8 @@ const tokenBundleAssetsMissingError: CreateErrorFunction = type =>
   buildApiError(Errors.TOKEN_BUNDLE_ASSETS_MISSING, false, type);
 const tokenAssetValueMissingError: CreateErrorFunction = type =>
   buildApiError(Errors.TOKEN_ASSET_VALUE_MISSING, false, type);
+const sendOutsideValidityIntervalUtxoError: CreateErrorFunction = (details?: string) =>
+  buildApiError(Errors.OUTSIDE_VALIDITY_INTERVAL_UTXO, false, details);
 
 export const ErrorFactory = {
   blockNotFoundError,
@@ -207,6 +213,7 @@ export const ErrorFactory = {
   cantCreateUnsignedTransactionFromBytes,
   missingMetadataParametersForPoolRetirement,
   sendTransactionError,
+  sendOutsideValidityIntervalUtxoError,
   transactionInputDeserializationError,
   transactionOutputDeserializationError,
   invalidPolicyIdError,

--- a/cardano-rosetta-server/test/e2e/construction/construction-submit-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-submit-api.test.ts
@@ -4,8 +4,11 @@ import StatusCodes from 'http-status-codes';
 import { Pool } from 'pg';
 import { FastifyInstance } from 'fastify';
 import { cardanoCliMock, setupOfflineDatabase, setupServer } from '../utils/test-utils';
-import { Errors } from '../../../src/server/utils/errors';
-import { CONSTRUCTION_SIGNED_TRANSACTION_WITH_EXTRA_DATA } from '../fixture-data';
+import { ErrorFactory, Errors } from '../../../src/server/utils/errors';
+import {
+  CONSTRUCTION_SIGNED_TRANSACTION_WITH_EXTRA_DATA,
+  CONSTRUCTION_SIGNED_TRANSACTION_WITH_EXTRA_DATA_INVALID_TTL
+} from '../fixture-data';
 
 const CONSTRUCTION_SUBMIT_ENDPOINT = '/construction/submit';
 
@@ -13,6 +16,9 @@ const generatePayloadWithSignedTransaction = (blockchain: string, network: strin
   network_identifier: { blockchain, network },
   signed_transaction: signedTransaction
 });
+
+const ERROR_WHEN_CALLING_CARDANO_CLI = 'Error when calling cardano-cli';
+const ERROR_OUTSIDE_VALIDITY_INTERVAL_UTXO = 'Error when sending the transaction - OutsideValidityIntervalUTxO';
 
 describe(CONSTRUCTION_SUBMIT_ENDPOINT, () => {
   let database: Pool;
@@ -80,7 +86,7 @@ describe(CONSTRUCTION_SUBMIT_ENDPOINT, () => {
     const mock = cardanoCliMock.submitTransaction as jest.Mock;
     mock.mockClear();
     mock.mockImplementation(() => {
-      throw new Error('Error when calling cardano-cli');
+      throw new Error(ERROR_WHEN_CALLING_CARDANO_CLI);
     });
     const response = await server.inject({
       method: 'post',
@@ -96,10 +102,37 @@ describe(CONSTRUCTION_SUBMIT_ENDPOINT, () => {
     expect(response.json()).toEqual({
       code: 5006,
       details: {
-        message: 'Error when calling cardano-cli'
+        message: ERROR_WHEN_CALLING_CARDANO_CLI
       },
       message: 'Error when sending the transaction',
       retriable: true
+    });
+  });
+
+  it('Should return an non retriable error if there is OutsideValidityIntervalUTxO error from the node', async () => {
+    const mock = cardanoCliMock.submitTransaction as jest.Mock;
+    mock.mockClear();
+    mock.mockImplementation(() => {
+      throw ErrorFactory.sendOutsideValidityIntervalUtxoError(ERROR_OUTSIDE_VALIDITY_INTERVAL_UTXO);
+    });
+    const response = await server.inject({
+      method: 'post',
+      url: CONSTRUCTION_SUBMIT_ENDPOINT,
+      payload: generatePayloadWithSignedTransaction(
+        'cardano',
+        'mainnet',
+        CONSTRUCTION_SIGNED_TRANSACTION_WITH_EXTRA_DATA_INVALID_TTL
+      )
+    });
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect((cardanoCliMock.submitTransaction as jest.Mock).mock.calls.length).toBe(1);
+    expect(response.json()).toEqual({
+      code: 4037,
+      details: {
+        message: ERROR_OUTSIDE_VALIDITY_INTERVAL_UTXO
+      },
+      message: ERROR_OUTSIDE_VALIDITY_INTERVAL_UTXO,
+      retriable: false
     });
   });
 });

--- a/cardano-rosetta-server/test/e2e/construction/construction-submit-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-submit-api.test.ts
@@ -128,9 +128,6 @@ describe(CONSTRUCTION_SUBMIT_ENDPOINT, () => {
     expect((cardanoCliMock.submitTransaction as jest.Mock).mock.calls.length).toBe(1);
     expect(response.json()).toEqual({
       code: 4037,
-      details: {
-        message: ERROR_OUTSIDE_VALIDITY_INTERVAL_UTXO
-      },
       message: ERROR_OUTSIDE_VALIDITY_INTERVAL_UTXO,
       retriable: false
     });

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -1381,6 +1381,87 @@ export const CONSTRUCTION_PAYLOADS_REQUEST: Components.Schemas.ConstructionPaylo
   }
 };
 
+export const CONSTRUCTION_PAYLOADS_REQUEST_INVALID_TTL: Components.Schemas.ConstructionPayloadsRequest = {
+  network_identifier: {
+    blockchain: 'cardano',
+    network: 'mainnet'
+  },
+  operations: [
+    {
+      operation_identifier: {
+        index: 0,
+        network_index: 0
+      },
+      type: OperationType.INPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '-90000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      },
+      coin_change: {
+        coin_identifier: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          identifier: '2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f:1'
+        },
+        coin_action: 'coin_spent'
+      }
+    },
+    {
+      operation_identifier: {
+        index: 1
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '10000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    },
+    {
+      operation_identifier: {
+        index: 2
+      },
+      related_operations: [
+        {
+          index: 0
+        }
+      ],
+      type: OperationType.OUTPUT,
+      status: 'success',
+      account: {
+        address: 'addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx'
+      },
+      amount: {
+        value: '40000',
+        currency: {
+          symbol: 'ADA',
+          decimals: 6
+        }
+      }
+    }
+  ],
+  metadata: {
+    ttl: '1'
+  }
+};
+
 export const CONSTRUCTION_PAYLOADS_REQUEST_WITH_BYRON_INPUT: Components.Schemas.ConstructionPayloadsRequest = {
   network_identifier: {
     blockchain: 'cardano',
@@ -4760,6 +4841,10 @@ export const CONSTRUCTION_SIGNED_TRANSACTION_WITH_SEVERAL_MA = cbor
 
 export const CONSTRUCTION_SIGNED_TRANSACTION_WITH_EXTRA_DATA = cbor
   .encode([SIGNED_TRANSACTION, constructionExtraData(CONSTRUCTION_PAYLOADS_REQUEST)])
+  .toString('hex');
+
+export const CONSTRUCTION_SIGNED_TRANSACTION_WITH_EXTRA_DATA_INVALID_TTL = cbor
+  .encode([SIGNED_TRANSACTION, constructionExtraData(CONSTRUCTION_PAYLOADS_REQUEST_INVALID_TTL)])
   .toString('hex');
 
 export const CONSTRUCTION_SIGNED_TX_WITH_POOL_REGISTRATION_AND_PLEDGE = cbor

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -155,6 +155,11 @@ const allow = {
       retriable: false
     },
     {
+      message: 'Error when sending the transaction - OutsideValidityIntervalUTxO',
+      code: 4037,
+      retriable: false
+    },
+    {
       code: 5000,
       message: 'An error occurred',
       retriable: true

--- a/cardano-rosetta-server/test/unit/utils/rosetta-error-mapper.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/rosetta-error-mapper.test.ts
@@ -9,13 +9,13 @@ describe('Node to Rosetta error (ApiError) mapper test', () => {
     }
   ];
 
-  it('should resolve ApiError from node error', async () => {
+  it('should resolve if the error is present', async () => {
     const resolved = ErrorUtils.resolveApiErrorFromNodeSourced('OutsideValidityIntervalUTxO', errors);
 
     await expect(resolved).resolves.toEqual(ErrorFactory.sendOutsideValidityIntervalUtxoError());
   });
 
-  it('should not resolve ApiError from node error', async () => {
+  it('should reject if the error is unknown', async () => {
     const resolved = ErrorUtils.resolveApiErrorFromNodeSourced('Some', errors);
 
     await expect(resolved).rejects.toMatch('error not found');

--- a/cardano-rosetta-server/test/unit/utils/rosetta-error-mapper.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/rosetta-error-mapper.test.ts
@@ -1,0 +1,23 @@
+import { ErrorFactory, Errors, ErrorUtils, nodeOutputToError } from '../../../src/server/utils/errors';
+
+describe('Node to Rosetta error (ApiError) mapper test', () => {
+  const errors: nodeOutputToError[] = [
+    {
+      error: Errors.OUTSIDE_VALIDITY_INTERVAL_UTXO,
+      inputPattern: new RegExp('OutsideValidityIntervalUTxO'),
+      retriable: false
+    }
+  ];
+
+  it('should resolve ApiError from node error', async () => {
+    const resolved = ErrorUtils.resolveApiErrorFromNodeSourced('OutsideValidityIntervalUTxO', errors);
+
+    await expect(resolved).resolves.toEqual(ErrorFactory.sendOutsideValidityIntervalUtxoError());
+  });
+
+  it('should not resolve ApiError from node error', async () => {
+    const resolved = ErrorUtils.resolveApiErrorFromNodeSourced('Some', errors);
+
+    await expect(resolved).rejects.toMatch('error not found');
+  });
+});


### PR DESCRIPTION
# Description

This is a fix for cardano rosetta implementation when cardano node throws OutsideValidityIntervalUTxO error and rosetta throws generic 5006 error code without any details what has happened.

# Proposed Solution

Introduce logic that maps cardano-node error to a broader rosetta api error.
Add OutsideValidityIntervalUTxO error within a new 4037 code.

# Important Changes Introduced

As stated above.

# Testing

Tests were updated.

