### PR TITLE
feat: filter invalid txs from utxo and balance queries

### DIFF
--- a/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
+++ b/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
@@ -435,7 +435,7 @@ const findBalanceByAddressAndBlock = `
   ) - (
     SELECT COALESCE(SUM(w.amount),0) 
     FROM withdrawal w
-    JOIN valid_tx ON tx.id = w.tx_id 
+    JOIN valid_tx AS tx ON tx.id = w.tx_id AND
       tx.block_id <= (SELECT id FROM block WHERE hash = $2)
     JOIN stake_address ON stake_address.id = w.addr_id
     WHERE stake_address.view = $1

--- a/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
+++ b/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
@@ -347,8 +347,17 @@ ${poolRegistrationQuery}
     ON prelay.update_id = pr."updateId"
 `;
 
+const validTxQuery = `
+  WITH valid_tx AS (
+    SELECT *
+    FROM tx
+    WHERE valid_contract = TRUE
+  )
+`;
+
 const utxoQuery = `
-WITH utxo AS (
+  ${validTxQuery},
+  utxo AS (
 	SELECT
 	  tx_out.value as value,
 	  tx_out_tx.hash as "txHash",
@@ -358,16 +367,17 @@ WITH utxo AS (
 	LEFT JOIN tx_in ON 
 	  tx_out.tx_id = tx_in.tx_out_id AND 
 	  tx_out.index::smallint = tx_in.tx_out_index::smallint 
-	LEFT JOIN tx as tx_in_tx ON 
+    LEFT JOIN valid_tx AS tx_in_tx ON 
 	  tx_in_tx.id = tx_in.tx_in_id AND
 	  tx_in_tx.block_id <= (select id from block where hash = $2)
-	JOIN tx AS tx_out_tx ON
+    JOIN valid_tx AS tx_out_tx ON
 	  tx_out_tx.id = tx_out.tx_id AND
 	  tx_out_tx.block_id <= (select id from block where hash = $2)
 	WHERE 
 	  tx_out.address = $1 AND
 	  tx_in_tx.id IS NULL
-)`;
+  )
+`;
 
 const findPoolRetirements = `
 SELECT 
@@ -414,19 +424,22 @@ const findMaBalanceByAddressAndBlock = `
 `;
 
 const findBalanceByAddressAndBlock = `
-  SELECT (SELECT COALESCE(SUM(r.amount),0) 
+  ${validTxQuery}
+  SELECT (
+    SELECT COALESCE(SUM(r.amount),0) 
       FROM reward r
     JOIN stake_address ON 
         stake_address.id = r.addr_id
     WHERE stake_address.view = $1
-    AND r.spendable_epoch <= (SELECT epoch_no FROM block WHERE hash = $2))- 
-    (SELECT COALESCE(SUM(w.amount),0) 
+    AND r.spendable_epoch <= (SELECT epoch_no FROM block WHERE hash = $2)
+  ) - (
+    SELECT COALESCE(SUM(w.amount),0) 
     FROM withdrawal w
-    JOIN tx ON tx.id = w.tx_id AND 
+    JOIN valid_tx ON tx.id = w.tx_id 
       tx.block_id <= (SELECT id FROM block WHERE hash = $2)
     JOIN stake_address ON stake_address.id = w.addr_id
-    WHERE stake_address.view = $1) 
-    AS balance
+    WHERE stake_address.view = $1
+  ) AS balance
 `;
 
 const findLatestMinFeeAAndMinFeeB = `


### PR DESCRIPTION
# Description

Filter invalid transaction from queries that calculate balance with the new `valid_contract` field introduced in Alonzo 