### PR TITLE
feat: add invalid operation status for invalid txs

### DIFF
--- a/cardano-rosetta-server/package.json
+++ b/cardano-rosetta-server/package.json
@@ -19,6 +19,9 @@
   "lint-staged": {
     "src/**/*.{js,ts}": [
       "npm run lint"
+    ],
+    "test/**/*.{js,ts}": [
+      "npm run lint"
     ]
   },
   "husky": {

--- a/cardano-rosetta-server/src/server/controllers/network-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/network-controller.ts
@@ -1,7 +1,13 @@
 import { FastifyRequest } from 'fastify';
 import { NetworkService } from '../services/network-service';
 import { CardanoNode } from '../utils/cardano/cli/cardano-node';
-import { MIDDLEWARE_VERSION, OPERATION_TYPES, ROSETTA_VERSION, SUCCESS_OPERATION_STATE } from '../utils/constants';
+import {
+  INVALID_OPERATION_STATE,
+  MIDDLEWARE_VERSION,
+  OPERATION_TYPES,
+  ROSETTA_VERSION,
+  SUCCESS_OPERATION_STATE
+} from '../utils/constants';
 import { mapToNetworkList, mapToNetworkStatusResponse } from '../utils/data-mapper';
 import { ErrorFactory } from '../utils/errors';
 import { withNetworkValidation } from './controllers-helper';
@@ -66,7 +72,7 @@ const configure = (networkService: NetworkService, cardanoNode: CardanoNode): Ne
             metadata: {}
           },
           allow: {
-            operation_statuses: [SUCCESS_OPERATION_STATE],
+            operation_statuses: [SUCCESS_OPERATION_STATE, INVALID_OPERATION_STATE],
             operation_types: OPERATION_TYPES,
             errors: Object.values(ErrorFactory)
               .map(fn => fn())

--- a/cardano-rosetta-server/src/server/db/blockchain-repository.ts
+++ b/cardano-rosetta-server/src/server/db/blockchain-repository.ts
@@ -122,7 +122,8 @@ const parseTransactionRows = (result: QueryResult<FindTransaction>): Transaction
     hash: hexFormatter(row.hash),
     blockHash: row.blockHash && hexFormatter(row.blockHash),
     fee: row.fee,
-    size: row.size
+    size: row.size,
+    validContract: row.validContract
   }));
 
 /**
@@ -140,6 +141,7 @@ const mapTransactionsToDict = (transactions: Transaction[]): TransactionsMap =>
         blockHash: transaction.blockHash,
         fee: transaction.fee,
         size: transaction.size,
+        validContract: transaction.validContract,
         inputs: [],
         outputs: [],
         withdrawals: [],
@@ -171,6 +173,7 @@ const mapToTransactionPoolRegistrations = (
       }));
     return {
       txHash: poolRegistration.txHash,
+      validContract: poolRegistration.validContract,
       vrfKeyHash: poolRegistration.vrfKeyHash,
       pledge: poolRegistration.pledge,
       margin: poolRegistration.margin,
@@ -301,7 +304,8 @@ const parseInputsRow = (
       address: queryResult.address,
       value: queryResult.value,
       sourceTransactionHash: hexFormatter(queryResult.sourceTxHash),
-      sourceTransactionIndex: queryResult.sourceTxIndex
+      sourceTransactionIndex: queryResult.sourceTxIndex,
+      validContract: queryResult.validContract
     }),
     (updatedTransaction, updatedCollection) => ({ ...updatedTransaction, inputs: updatedCollection })
   );

--- a/cardano-rosetta-server/src/server/db/blockchain-repository.ts
+++ b/cardano-rosetta-server/src/server/db/blockchain-repository.ts
@@ -173,7 +173,6 @@ const mapToTransactionPoolRegistrations = (
       }));
     return {
       txHash: poolRegistration.txHash,
-      validContract: poolRegistration.validContract,
       vrfKeyHash: poolRegistration.vrfKeyHash,
       pledge: poolRegistration.pledge,
       margin: poolRegistration.margin,
@@ -304,8 +303,7 @@ const parseInputsRow = (
       address: queryResult.address,
       value: queryResult.value,
       sourceTransactionHash: hexFormatter(queryResult.sourceTxHash),
-      sourceTransactionIndex: queryResult.sourceTxIndex,
-      validContract: queryResult.validContract
+      sourceTransactionIndex: queryResult.sourceTxIndex
     }),
     (updatedTransaction, updatedCollection) => ({ ...updatedTransaction, inputs: updatedCollection })
   );

--- a/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
+++ b/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
@@ -69,7 +69,6 @@ WHERE
 
 export interface FindTransactionFieldResult {
   txHash: Buffer;
-  validContract: boolean;
 }
 
 export interface FindTransactionInOutResult extends FindTransactionFieldResult {
@@ -109,7 +108,6 @@ const findTransactionsInputs = `SELECT
   source_tx_out.address as address,
   source_tx_out.value as value,
   tx.hash as "txHash",
-  tx.valid_contract as "validContract",
   source_tx.hash as "sourceTxHash",
   tx_in.tx_out_index as "sourceTxIndex",
   source_ma_tx_out.policy as policy,
@@ -150,7 +148,6 @@ SELECT
   address,
   value,
   tx.hash as "txHash",
-  tx.valid_contract as "validContract",
   index,
   ma_tx_out.policy as policy,
   ma_tx_out.name as name,
@@ -190,8 +187,7 @@ const findTransactionWithdrawals = `
 SELECT 
   amount,
   sa.view as "address",
-  tx.hash as "txHash",
-  tx.valid_contract as "validContract"
+  tx.hash as "txHash"
 FROM withdrawal w
 INNER JOIN tx on w.tx_id = tx.id
 INNER JOIN stake_address sa on w.addr_id = sa.id
@@ -229,8 +225,7 @@ const findTransactionRegistrations = `
 SELECT 
   tx.deposit as "amount",
   sa.view as "address",
-  tx.hash as "txHash",
-  tx.valid_contract as "validContract"
+  tx.hash as "txHash"
 FROM stake_registration sr
 INNER JOIN tx on tx.id = sr.tx_id
 INNER JOIN stake_address sa on sr.addr_id = sa.id
@@ -242,8 +237,7 @@ const findTransactionDeregistrations = `
 SELECT 
   sa.view as "address",
   tx.deposit as "amount",
-  tx.hash as "txHash",
-  tx.valid_contract as "validContract"
+  tx.hash as "txHash"
 FROM stake_deregistration sd
 INNER JOIN stake_address sa
   ON sd.addr_id = sa.id
@@ -256,8 +250,7 @@ const findTransactionDelegations = `
 SELECT 
   sa.view as "address",
   ph.hash_raw as "poolHash",
-  tx.hash as "txHash",
-  tx.valid_contract as "validContract"
+  tx.hash as "txHash"
 FROM delegation d
 INNER JOIN stake_address sa
   ON d.addr_id = sa.id
@@ -307,7 +300,6 @@ const poolRegistrationQuery = `
   SELECT
     tx.hash as "txHash",
     tx.id as "txId",
-    tx.valid_contract as "validContract",
     pu.id as "updateId",
     ph.id as "poolId",
     pu.vrf_key_hash as "vrfKeyHash",
@@ -341,8 +333,7 @@ ${poolRegistrationQuery}
     SELECT 
       po.pool_hash_id AS "poolId",
       sa."view" AS "owner",
-      pr."txHash",
-      pr."validContract"
+      pr."txHash"
     FROM pool_registration pr
     JOIN pool_owner po
       ON  (po.pool_hash_id = pr."poolId" 
@@ -359,8 +350,7 @@ ${poolRegistrationQuery}
       prelay.ipv6 as ipv6,
       prelay.port as port,
       prelay.dns_name as "dnsName",
-      pr."txHash",
-      pr."validContract"
+      pr."txHash"
     FROM pool_registration pr
     JOIN pool_relay prelay
     ON prelay.update_id = pr."updateId"
@@ -402,8 +392,7 @@ const findPoolRetirements = `
 SELECT 
   pr.retiring_epoch AS "epoch",
   ph.hash_raw AS "address",
-  tx.hash as "txHash",
-  tx.valid_contract as "validContract"
+  tx.hash as "txHash"
 FROM pool_retire pr 
 INNER JOIN pool_hash ph 
   ON pr.hash_id = ph.id

--- a/cardano-rosetta-server/src/server/models.ts
+++ b/cardano-rosetta-server/src/server/models.ts
@@ -95,6 +95,7 @@ export interface PoolRelay {
 
 export interface TransactionPoolRegistrations {
   txHash: Buffer;
+  validContract: boolean;
   vrfKeyHash: Buffer;
   pledge: string;
   margin: string;
@@ -135,6 +136,7 @@ export interface Transaction {
   blockHash: string;
   fee: string;
   size: number;
+  validContract: boolean;
 }
 
 export interface PopulatedTransaction extends Transaction {

--- a/cardano-rosetta-server/src/server/models.ts
+++ b/cardano-rosetta-server/src/server/models.ts
@@ -95,7 +95,6 @@ export interface PoolRelay {
 
 export interface TransactionPoolRegistrations {
   txHash: Buffer;
-  validContract: boolean;
   vrfKeyHash: Buffer;
   pledge: string;
   margin: string;

--- a/cardano-rosetta-server/src/server/utils/constants.ts
+++ b/cardano-rosetta-server/src/server/utils/constants.ts
@@ -68,8 +68,9 @@ export const PoolOperations = [
   OperationType.POOL_REGISTRATION_WITH_CERT
 ];
 
-enum OperationTypeStatus {
-  SUCCESS = 'success'
+export enum OperationTypeStatus {
+  SUCCESS = 'success',
+  INVALID = 'invalid'
 }
 
 export enum CurveType {
@@ -88,6 +89,10 @@ export const MAIN_TESTNET_NETWORK_MAGIC = 1097911063;
 export const SUCCESS_OPERATION_STATE = {
   status: OperationTypeStatus.SUCCESS,
   successful: true
+};
+export const INVALID_OPERATION_STATE = {
+  status: OperationTypeStatus.INVALID,
+  successful: false
 };
 
 export enum AddressType {

--- a/cardano-rosetta-server/src/server/utils/data-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/data-mapper.ts
@@ -20,6 +20,7 @@ import {
   MULTI_ASSET_DECIMALS,
   NetworkIdentifier,
   OperationType,
+  OperationTypeStatus,
   PoolOperations,
   SIGNATURE_TYPE,
   StakingOperations,
@@ -131,11 +132,12 @@ export const mapToRosettaTransaction = (
   transaction: PopulatedTransaction,
   poolDeposit: number
 ): Components.Schemas.Transaction => {
+  const status = transaction.validContract ? OperationTypeStatus.SUCCESS : OperationTypeStatus.INVALID;
   const inputsAsOperations = transaction.inputs.map((input, index) =>
     createOperation(
       index,
       OperationType.INPUT,
-      SUCCESS_STATUS,
+      status,
       input.address,
       mapValue(input.value, true),
       undefined,
@@ -150,7 +152,7 @@ export const mapToRosettaTransaction = (
       index: getOperationCurrentIndex(totalOperations, index)
     },
     type: OperationType.WITHDRAWAL,
-    status: SUCCESS_STATUS,
+    status,
     account: {
       address: withdrawal.stakeAddress
     },
@@ -165,7 +167,7 @@ export const mapToRosettaTransaction = (
         index: getOperationCurrentIndex(totalOperations, index)
       },
       type: OperationType.STAKE_KEY_REGISTRATION,
-      status: SUCCESS_STATUS,
+      status,
       account: {
         address: registration.stakeAddress
       },
@@ -181,7 +183,7 @@ export const mapToRosettaTransaction = (
         index: getOperationCurrentIndex(totalOperations, index)
       },
       type: OperationType.POOL_RETIREMENT,
-      status: SUCCESS_STATUS,
+      status,
       account: {
         address: poolRetirement.address
       },
@@ -198,7 +200,7 @@ export const mapToRosettaTransaction = (
         index: getOperationCurrentIndex(totalOperations, index)
       },
       type: OperationType.STAKE_KEY_DEREGISTRATION,
-      status: SUCCESS_STATUS,
+      status,
       account: {
         address: deregistration.stakeAddress
       },
@@ -213,7 +215,7 @@ export const mapToRosettaTransaction = (
       index: getOperationCurrentIndex(totalOperations, index)
     },
     type: OperationType.STAKE_DELEGATION,
-    status: SUCCESS_STATUS,
+    status,
     account: {
       address: delegation.stakeAddress
     },
@@ -228,7 +230,7 @@ export const mapToRosettaTransaction = (
         index: getOperationCurrentIndex(totalOperations, index)
       },
       type: OperationType.POOL_REGISTRATION,
-      status: SUCCESS_STATUS,
+      status,
       account: {
         // public cold key
         address: poolRegistration.poolHash
@@ -260,7 +262,7 @@ export const mapToRosettaTransaction = (
     createOperation(
       getOperationCurrentIndex(totalOperations, index),
       OperationType.OUTPUT,
-      SUCCESS_STATUS,
+      status,
       output.address,
       output.value,
       relatedOperations,

--- a/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
@@ -43,9 +43,13 @@ const ACCOUNT_BALANCE_ENDPOINT = '/account/balance';
 describe('/account/balance endpoint', () => {
   let database: Pool;
   let server: FastifyInstance;
+  let alonzoDatabase: Pool;
+  let serverWithAlonzoSupport: FastifyInstance;
   beforeAll(async () => {
     database = setupDatabase();
     server = setupServer(database);
+    alonzoDatabase = setupDatabase(process.env.DB_CONNECTION_STRING, 'purple');
+    serverWithAlonzoSupport = setupServer(alonzoDatabase);
   });
 
   afterAll(async () => {
@@ -241,6 +245,29 @@ describe('/account/balance endpoint', () => {
           }
         }
       ]
+    });
+  });
+  // at this block there is a total amount of 4828955 that are part of an invalid tx
+  // and shouldn't be counted
+  test('should not count utxos of an invalid tx', async () => {
+    const response = await serverWithAlonzoSupport.inject({
+      method: 'post',
+      url: ACCOUNT_BALANCE_ENDPOINT,
+      payload: generatePayload(
+        CARDANO,
+        'mainnet',
+        'addr_test1vpdvkurqk92detyluym8s6pg3gkf5nlah834rag4rntylzs9p3d0g',
+        25050,
+        '1f58250b82bc7c7c408028ba01173bdfa37fc82dde34060c5b49a3ea644d9439'
+      )
+    });
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual({
+      balances: [{ currency: { decimals: 6, symbol: 'ADA' }, value: '999972560720' }],
+      block_identifier: {
+        index: 25050,
+        hash: '1f58250b82bc7c7c408028ba01173bdfa37fc82dde34060c5b49a3ea644d9439'
+      }
     });
   });
   test('should return 0 for the balance of stake account at block with no earned rewards', async () => {

--- a/cardano-rosetta-server/test/e2e/block/block-transactions-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/block/block-transactions-api.test.ts
@@ -336,6 +336,7 @@ describe('/block/transactions endpoint', () => {
       url: BLOCK_TRANSACTION_ENDPOINT,
       payload: {
         ...generatePayload(blockNumber, blockHash),
+        // eslint-disable-next-line camelcase
         transaction_identifier: {
           hash: invalidTxHash
         }

--- a/cardano-rosetta-server/test/e2e/block/block-transactions-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/block/block-transactions-api.test.ts
@@ -12,7 +12,8 @@ import {
   transactionBlock4597861WithWithdrawals,
   transactionBlock4853177WithDeregistration,
   transactionBlock4853177WithPoolRetirement,
-  transactionWithPoolRegistrationWithMultipleOwners
+  transactionWithPoolRegistrationWithMultipleOwners,
+  invalidAlonzoTransaction
 } from '../fixture-data';
 import { setupDatabase, setupServer } from '../utils/test-utils';
 
@@ -34,9 +35,13 @@ const generatePayload = (index?: number, hash?: string, blockchain?: string, net
 describe('/block/transactions endpoint', () => {
   let database: Pool;
   let server: FastifyInstance;
+  let alonzoDatabase: Pool;
+  let serverWithAlonzoSupport: FastifyInstance;
   beforeAll(async () => {
     database = setupDatabase();
     server = setupServer(database);
+    alonzoDatabase = setupDatabase(process.env.DB_CONNECTION_STRING, 'purple');
+    serverWithAlonzoSupport = setupServer(alonzoDatabase);
   });
 
   afterAll(async () => {
@@ -319,5 +324,25 @@ describe('/block/transactions endpoint', () => {
     });
     expect(response.statusCode).toEqual(StatusCodes.OK);
     expect(response.json()).toEqual(transactionWithPoolRegistrationWithMultipleOwners);
+  });
+
+  test('should return operation status as invalid when there is an invalid transaction', async () => {
+    const invalidTxHash = '0c2d516c9eaf0d9f641506f1f64be3f660a49e622f4651ed1b19d6edeaefaf4c';
+    const blockNumber = 25050;
+    const blockHash = '1f58250b82bc7c7c408028ba01173bdfa37fc82dde34060c5b49a3ea644d9439';
+
+    const response = await serverWithAlonzoSupport.inject({
+      method: 'post',
+      url: BLOCK_TRANSACTION_ENDPOINT,
+      payload: {
+        ...generatePayload(blockNumber, blockHash),
+        transaction_identifier: {
+          hash: invalidTxHash
+        }
+      }
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.OK);
+    expect(response.json()).toEqual(invalidAlonzoTransaction);
   });
 });

--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -958,6 +958,51 @@ export const transaction987aOnGenesis = {
   }
 };
 
+export const invalidAlonzoTransaction = {
+  transaction: {
+    operations: [
+      {
+        operation_identifier: { index: 0 },
+        type: 'input',
+        status: 'invalid',
+        account: { address: 'addr_test1vpdvkurqk92detyluym8s6pg3gkf5nlah834rag4rntylzs9p3d0g' },
+        amount: { value: '-10000000', currency: { symbol: 'ADA', decimals: 6 } },
+        coin_change: {
+          coin_identifier: { identifier: 'b2cf437085d433e75b273adc4efe62fffcdc7fa3d3c821d3994814301df911b0:1' },
+          coin_action: 'coin_spent'
+        }
+      },
+      {
+        operation_identifier: { index: 1, network_index: 0 },
+        related_operations: [{ index: 0 }],
+        type: 'output',
+        status: 'invalid',
+        account: { address: 'addr_test1vpdvkurqk92detyluym8s6pg3gkf5nlah834rag4rntylzs9p3d0g' },
+        amount: { value: '1828955', currency: { symbol: 'ADA', decimals: 6 } },
+        coin_change: {
+          coin_identifier: { identifier: '0c2d516c9eaf0d9f641506f1f64be3f660a49e622f4651ed1b19d6edeaefaf4c:0' },
+          coin_action: 'coin_created'
+        }
+      },
+      {
+        operation_identifier: { index: 2, network_index: 1 },
+        related_operations: [{ index: 0 }],
+        type: 'output',
+        status: 'invalid',
+        account: { address: 'addr_test1vpdvkurqk92detyluym8s6pg3gkf5nlah834rag4rntylzs9p3d0g' },
+        amount: { value: '3000000', currency: { symbol: 'ADA', decimals: 6 } },
+        coin_change: {
+          coin_identifier: { identifier: '0c2d516c9eaf0d9f641506f1f64be3f660a49e622f4651ed1b19d6edeaefaf4c:1' },
+          coin_action: 'coin_created'
+        }
+      }
+    ],
+    transaction_identifier: {
+      hash: '0c2d516c9eaf0d9f641506f1f64be3f660a49e622f4651ed1b19d6edeaefaf4c'
+    }
+  }
+};
+
 // The following test vectors
 // ./cardano-cli shelley transaction build-raw --tx-in 2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f#1 \
 //  --tx-out addr1vxa5pudxg77g3sdaddecmw8tvc6hmynywn49lltt4fmvn7cpnkcpx +10000 \

--- a/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/network/network-options-api.test.ts
@@ -14,6 +14,10 @@ const allow = {
     {
       status: 'success',
       successful: true
+    },
+    {
+      status: 'invalid',
+      successful: false
     }
   ],
   operation_types: OPERATION_TYPES,


### PR DESCRIPTION
# Description

This PR adds a new operation status for invalid transactions depending on the `valid_contract` field