### PR TITLE
fix: pool registration workflow config fix

### DIFF
--- a/test/check/configuration/construction/pool-registration-configuration.json
+++ b/test/check/configuration/construction/pool-registration-configuration.json
@@ -24,7 +24,7 @@
       "constructor_dsl_file": "../../workflows/pool-registration.ros",
       "end_conditions": {
         "create_account": 1,
-        "pool-registration": 1
+        "pool_registration": 1
       }
     }
   }


### PR DESCRIPTION
# Description

Fixes typo error on end condition of pool registration config workflow

