### PR TITLE
docs: improve docs to cover Docker Hub repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Cardano Rosetta
 [![CI][img_src_CI]][workflow_CI] [![Nightly][img_src_Nightly]][workflow_Nightly] [![Postman Send Transaction Example](https://github.com/input-output-hk/cardano-rosetta/actions/workflows/postman_send_transaction_example.yml/badge.svg)](https://github.com/input-output-hk/cardano-rosetta/actions/workflows/postman_send_transaction_example.yml)
 
-An implementation of [Rosetta] for [Cardano], targeting the version defined in the [OpenApi schema]
+An implementation of [Rosetta] for [Cardano], targeting the version defined in the [OpenApi 
+schema]. Skip to [run](#run) if wishing to use a pre-built image from the [Docker Hub repository]. 
+
+
 ## Build
 
 ### [From anywhere]
@@ -23,29 +26,72 @@ docker build -t cardano-rosetta .
 
 **_Optionally_** use cached build layers to reduce the initialization time. Suits dev and demo 
 use-cases:
+
+### mainnet
 ```console
 export DOCKER_BUILDKIT=1
 docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     --cache-from=inputoutput/cardano-rosetta:master \
-    -t cardano-rosetta:1.4.0-beta.0 \
-    https://github.com/input-output-hk/cardano-rosetta.git#1.4.0-beta.0
+    -t inputoutput/cardano-rosetta:1.4.0-beta.1 \
+    https://github.com/input-output-hk/cardano-rosetta.git#1.4.0-beta.1
+```
+
+### testnet
+```console
+export DOCKER_BUILDKIT=1
+docker build \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --cache-from=inputoutput/cardano-rosetta:master \
+    -t inputoutput/cardano-rosetta:1.4.0-beta.1-testnet \
+    https://github.com/input-output-hk/cardano-rosetta.git#1.4.0-beta.1
+```
+
+### alonzo-purple
+```console
+export DOCKER_BUILDKIT=1
+docker build \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --cache-from=inputoutput/cardano-rosetta:master \
+    -t inputoutput/cardano-rosetta:1.4.0-beta.1-alonzo-purple \
+    https://github.com/input-output-hk/cardano-rosetta.git#1.4.0-beta.1
 ```
 
 ## Run
+Run the locally built or pre-built images and mount a single volume into the [standard storage 
+location], map the server port to the host, and allocate a suitably-sized `/dev/shm`. See the 
+complete [Docker run reference] for full control.
 
-Mount a single volume into the [standard storage location], mapping the server port to the host, 
-and allocating a suitably-sized `/dev/shm`. See the complete [Docker run reference] for full 
-control.
-
+### mainnet
 ```console
 docker run \
   --name cardano-rosetta \
   -p 8080:8080 \
   -v cardano-rosetta:/data \
   --shm-size=2g \
-  cardano-rosetta:1.4.0-beta.0
+  inputoutput/cardano-rosetta:1.4.0-beta.1
 ```
+
+### testnet
+```console
+docker run \
+  --name cardano-rosetta-testnet \
+  -p 8081:8080 \
+  -v cardano-rosetta-testnet:/data \
+  --shm-size=2g \
+  inputoutput/cardano-rosetta:1.4.0-beta.1-testnet
+```
+
+### alonzo-purple
+```console
+docker run \
+  --name cardano-rosetta-alonzo-purple \
+  -p 8082:8080 \
+  -v cardano-rosetta-alonzo-purple:/data \
+  --shm-size=2g \
+  inputoutput/cardano-rosetta:1.4.0-beta.1-alonzo-purple
+```
+
 ### Configuration
 
 Set ENVs for optional runtime configuration
@@ -108,6 +154,7 @@ Now create a new container using the run instructions above. Sync progress will 
 [Rosetta]: https://www.rosetta-api.org/docs/welcome.html
 [Cardano]: https://cardano.org/
 [OpenApi schema]: cardano-rosetta-server/src/server/openApi.json#L4
+[Docker Hub repository]: https://hub.docker.com/r/inputoutput/cardano-rosetta/tags?page=1&ordering=last_updated
 [From anywhere]: https://www.rosetta-api.org/docs/node_deployment.html#build-anywhere
 [network]: config/network
 [standard storage location]: https://www.rosetta-api.org/docs/standard_storage_location.html

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ docker build -t cardano-rosetta .
 **_Optionally_** use cached build layers to reduce the initialization time. Suits dev and demo 
 use-cases:
 
-### mainnet
+<details open>
+  <summary>mainnet</summary>
+
 ```console
 export DOCKER_BUILDKIT=1
 docker build \
@@ -37,7 +39,11 @@ docker build \
     https://github.com/input-output-hk/cardano-rosetta.git#1.4.0-beta.1
 ```
 
-### testnet
+</details>
+
+<details>
+  <summary>testnet</summary>
+
 ```console
 export DOCKER_BUILDKIT=1
 docker build \
@@ -47,7 +53,11 @@ docker build \
     https://github.com/input-output-hk/cardano-rosetta.git#1.4.0-beta.1
 ```
 
-### alonzo-purple
+</details>
+
+<details>
+  <summary>alonzo-purple</summary>
+
 ```console
 export DOCKER_BUILDKIT=1
 docker build \
@@ -57,12 +67,17 @@ docker build \
     https://github.com/input-output-hk/cardano-rosetta.git#1.4.0-beta.1
 ```
 
+</details>
+
+
 ## Run
 Run the locally built or pre-built images and mount a single volume into the [standard storage 
 location], map the server port to the host, and allocate a suitably-sized `/dev/shm`. See the 
 complete [Docker run reference] for full control.
 
-### mainnet
+<details open>
+  <summary>mainnet</summary>
+
 ```console
 docker run \
   --name cardano-rosetta \
@@ -72,7 +87,11 @@ docker run \
   inputoutput/cardano-rosetta:1.4.0-beta.1
 ```
 
-### testnet
+</details>
+
+<details>
+  <summary>testnet</summary>
+
 ```console
 docker run \
   --name cardano-rosetta-testnet \
@@ -82,7 +101,11 @@ docker run \
   inputoutput/cardano-rosetta:1.4.0-beta.1-testnet
 ```
 
-### alonzo-purple
+</details>
+
+<details>
+  <summary>alonzo-purple</summary>
+
 ```console
 docker run \
   --name cardano-rosetta-alonzo-purple \
@@ -91,6 +114,8 @@ docker run \
   --shm-size=2g \
   inputoutput/cardano-rosetta:1.4.0-beta.1-alonzo-purple
 ```
+
+</details>
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ docker build \
 DOCKER_BUILDKIT=1 \
 docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --build-arg NETWORK=testnet \
     --cache-from=inputoutput/cardano-rosetta:master \
     -t inputoutput/cardano-rosetta:1.4.0-beta.1-testnet \
     https://github.com/input-output-hk/cardano-rosetta.git#1.4.0-beta.1
@@ -62,6 +63,7 @@ docker build \
 DOCKER_BUILDKIT=1 \ 
 docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --build-arg NETWORK=alonzo-purple \
     --cache-from=inputoutput/cardano-rosetta:master \
     -t inputoutput/cardano-rosetta:1.4.0-beta.1-alonzo-purple \
     https://github.com/input-output-hk/cardano-rosetta.git#1.4.0-beta.1

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ schema]. Skip to [run](#run) if wishing to use a pre-built image from the [Docke
 ### [From anywhere]
 
 ```console
-docker build -t cardano-rosetta:1.4.0-beta.0 https://github.com/input-output-hk/cardano-rosetta.
-git#1.4.0-beta.0
+docker build -t cardano-rosetta:1.4.0-beta.1 https://github.com/input-output-hk/cardano-rosetta.
+git#1.4.0-beta.1
 ```
 ### With local source code
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ use-cases:
   <summary>mainnet</summary>
 
 ```console
-DOCKER_BUILDKIT=1 \ 
+DOCKER_BUILDKIT=1 \
 docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     --cache-from=inputoutput/cardano-rosetta:master \
@@ -60,7 +60,7 @@ docker build \
   <summary>alonzo-purple</summary>
 
 ```console
-DOCKER_BUILDKIT=1 \ 
+DOCKER_BUILDKIT=1 \
 docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     --build-arg NETWORK=alonzo-purple \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ use-cases:
   <summary>mainnet</summary>
 
 ```console
-export DOCKER_BUILDKIT=1
+DOCKER_BUILDKIT=1 \ 
 docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     --cache-from=inputoutput/cardano-rosetta:master \
@@ -45,7 +45,7 @@ docker build \
   <summary>testnet</summary>
 
 ```console
-export DOCKER_BUILDKIT=1
+DOCKER_BUILDKIT=1 \
 docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     --cache-from=inputoutput/cardano-rosetta:master \
@@ -59,7 +59,7 @@ docker build \
   <summary>alonzo-purple</summary>
 
 ```console
-export DOCKER_BUILDKIT=1
+DOCKER_BUILDKIT=1 \ 
 docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     --cache-from=inputoutput/cardano-rosetta:master \


### PR DESCRIPTION
# Description
The documentation currently doesn't allow for seamless communication of remote vs locally built running. It's also not user-friendly for copy/paste.  

# Proposed Solution

- Changes the build step to tag with the org scope to allow common run commands.
- Adds specific commands for each supported network, to facilitate copy/paste, assigning a
different port to allow parallel running.
- Non-breaking since mainnet volume is the same.

# Testing
- Chicken-before-egg situation here in an attempt to expedite the process, so please replace the currently unreleased version with `master` in tests. 