### PR TITLE
Fix parsed inputs on /construction/parse

### DIFF
--- a/cardano-rosetta-server/src/server/utils/cardano/transactions-processor.ts
+++ b/cardano-rosetta-server/src/server/utils/cardano/transactions-processor.ts
@@ -464,10 +464,11 @@ export const convert = (
   const inputsCount = transactionBody.inputs().len();
   const outputsCount = transactionBody.outputs().len();
   logger.info(`[parseOperationsFromTransactionBody] About to parse ${inputsCount} inputs`);
+  const inputOperations = extraData.operations.filter(({ type }) => type === OperationType.INPUT);
   for (let i = 0; i < inputsCount; i++) {
     const input = transactionBody.inputs().get(i);
     const inputParsed = parseInputToOperation(input, operations.length);
-    operations.push({ ...inputParsed, ...extraData.operations[i], status: '' });
+    operations.push({ ...inputParsed, ...inputOperations[i], status: '' });
   }
   // till this line operations only contains inputs
   const relatedOperations = getRelatedOperationsFromInputs(operations);


### PR DESCRIPTION
# Description

Fixes a bug on `construction/parse` where inputs weren't correctly parsed and other operations data were being returned instead. In order to replicate this bug a transaction with 1 output, 1 input and 1 vote registration can be created and then parsed using the mentioned endpoint.
