### PR TITLE
feat: cardano-db-sync snapshot restoration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,14 +160,17 @@ CMD ["node", "/cardano-rosetta-server/dist/src/server/index.js"]
 
 FROM runtime-base
 ARG NETWORK=mainnet
+ARG SNAPSHOT_URL
 ENV DEFAULT_RELATIVE_TTL=1000 LOGGER_MIN_SEVERITY=info PAGE_SIZE=25
 COPY --from=rosetta-server-builder /app/dist /cardano-rosetta-server/dist
 COPY --from=rosetta-server-production-deps /app/node_modules /cardano-rosetta-server/node_modules
 COPY ecosystem.config.js .
 COPY postgresql.conf /etc/postgresql/12/main/postgresql.conf
-COPY scripts/start_cardano-db-sync.sh /scripts/
+COPY scripts/start_cardano-db-sync.sh scripts/maybe_download_cardano-db-sync_snapshot.sh /scripts/
 COPY config/network/${NETWORK} /config/
 ENV PGPASSFILE=/config/cardano-db-sync/pgpass
 RUN echo "/var/run/postgresql:5432:cexplorer:*:*" > $PGPASSFILE &&\
  chmod 600 $PGPASSFILE && chown postgres:postgres $PGPASSFILE
+RUN mkdir /snapshot &&\
+  ./scripts/maybe_download_cardano-db-sync_snapshot.sh $SNAPSHOT_URL /snapshot
 COPY scripts/entrypoint.sh .

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ docker run \
 
 </details>
 
+:information_source: _A trusted DB snapshot can be used to speed up the initial sync, however
+the internal instance of `cardano-node` must be synced past the snapshot point for it to be
+applied. This can be achieved by observing logs emitted from `cardano-node` indicating it's 
+close to the network tip, before then following the instructions in the [Upgrading section](#upgrading)._
+
 ### Configuration
 
 Set ENVs for optional runtime configuration
@@ -173,10 +178,10 @@ docker run \
 :information_source: _Build a new image as per the [standard build instructions] if you need to 
 recreate the container, otherwise the data will be dropped and restored again._
 
-:information_source: _The snapshot will not be applied if there is no prior `cardano-node` state,
-since the benefit of using it would be eliminated given `cardano-db-sync` rolls back to genesis 
-under these conditions. For best results, ensure the node is close to the network tip prior to
-upgrading._ 
+:information_source: _The snapshot will only be applied if `cardano-node` is synced past the 
+snapshot point, since the benefit of using it would be eliminated given `cardano-db-sync` rolls back
+to genesis under these conditions. For best results, ensure the node is close to the network tip
+prior to upgrading._ 
 
 #### 2. Re-sync From Genesis
 A _trustless_ approach to rebuild the DB, by syncing from genesis at the cost of an extended sync 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ build with local source by replacing the GitHub link with `.`
 ```console
 DOCKER_BUILDKIT=1 \
 docker build \
-    --build-arg BUILDKIT_INLINE_CACHE=1 \
-    --cache-from=inputoutput/cardano-rosetta:master \
-    -t inputoutput/cardano-rosetta:1.5.0 \
-    https://github.com/input-output-hk/cardano-rosetta.git#1.5.0
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --cache-from=inputoutput/cardano-rosetta:master \
+  -t inputoutput/cardano-rosetta:1.5.0 \
+  https://github.com/input-output-hk/cardano-rosetta.git#1.5.0
 ```
 
 </details>
@@ -30,11 +30,11 @@ docker build \
 ```console
 DOCKER_BUILDKIT=1 \
 docker build \
-    --build-arg BUILDKIT_INLINE_CACHE=1 \
-    --build-arg NETWORK=testnet \
-    --cache-from=inputoutput/cardano-rosetta:master \
-    -t inputoutput/cardano-rosetta:1.5.0-testnet \
-    https://github.com/input-output-hk/cardano-rosetta.git#1.5.0
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --build-arg NETWORK=testnet \
+  --cache-from=inputoutput/cardano-rosetta:master \
+  -t inputoutput/cardano-rosetta:1.5.0-testnet \
+  https://github.com/input-output-hk/cardano-rosetta.git#1.5.0
 ```
 
 </details>
@@ -105,18 +105,77 @@ following approached:
 
 #### 1. Apply a Trusted `cardano-db-sync` Snapshot
 Run the build command with the addition of an argument providing a version and network-specific 
-link, sourced from the 
-`cardano-db-sync` [release 
-notes](https://github.com/input-output-hk/cardano-db-sync/releases). For example version 11 on 
-_testnet_, captured at block `3022711`:
+link, sourced from the `cardano-db-sync` [release notes](https://github.com/input-output-hk/cardano-db-sync/releases).
+For example:
+
+##### Build
+<details open>
+  <summary>mainnet</summary>
+
+```console
+DOCKER_BUILDKIT=1 \
+docker build \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --build-arg SNAPSHOT_URL=https://update-cardano-mainnet.iohk.io/cardano-db-sync/11/db-sync-snapshot-schema-11-block-6426045-x86_64.tgz \
+  --cache-from=inputoutput/cardano-rosetta:master \
+  -t inputoutput/cardano-rosetta:1.5.0-apply-snapshot \
+  https://github.com/input-output-hk/cardano-rosetta.git#1.5.0
 ```
---build-arg SNAPSHOT_URL=https://updates-cardano-testnet.s3.amazonaws.com/cardano-db-sync/11/db-sync-snapshot-schema-11-block-3022711-x86_64.tgz
+
+</details>
+
+<details>
+  <summary>testnet</summary>
+
+```console
+DOCKER_BUILDKIT=1 \
+docker build \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --build-arg NETWORK=testnet \
+  --build-arg SNAPSHOT_URL=https://updates-cardano-testnet.s3.amazonaws.com/cardano-db-sync/11/db-sync-snapshot-schema-11-block-3022711-x86_64.tgz \
+  --cache-from=inputoutput/cardano-rosetta:master \
+  -t inputoutput/cardano-rosetta:1.5.0-testnet-apply-snapshot \
+  https://github.com/input-output-hk/cardano-rosetta.git#1.5.0
 ```
-... then start a container as per usual.
+
+</details>
+
+##### Run
+
+<details open>
+  <summary>mainnet</summary>
+
+```console
+docker run \
+  --name cardano-rosetta \
+  -p 8080:8080 \
+  -v cardano-rosetta:/data \
+  --shm-size=2g \
+  inputoutput/cardano-rosetta:1.5.0-apply-snapshot
+```
+
+</details>
+
+<details>
+  <summary>testnet</summary>
+
+```console
+docker run \
+  --name cardano-rosetta-testnet \
+  -p 8081:8080 \
+  -v cardano-rosetta-testnet:/data \
+  --shm-size=2g \
+  inputoutput/cardano-rosetta:1.5.0-testnet-apply-snapshot
+```
+
+</details>
+
+:information_source: _Build a new image as per the [standard build instructions] if you need to 
+recreate the container, otherwise the data will be dropped and restored again._
 
 :information_source: _The snapshot will not be applied if there is no prior `cardano-node` state,
-since the benefit of using the snapshot would be eliminated given `cardano-db-sync` would be
-rolling back to genesis. For best results, ensure the node is close to the network tip prior to
+since the benefit of using it would be eliminated given `cardano-db-sync` rolls back to genesis 
+under these conditions. For best results, ensure the node is close to the network tip prior to
 upgrading._ 
 
 #### 2. Re-sync From Genesis
@@ -160,6 +219,7 @@ docker run --rm -v cardano-rosetta:/data ubuntu rm -rf /data/postgresql /data/db
 [Docker run reference]: https://docs.docker.com/engine/reference/run/
 [modes]: https://www.rosetta-api.org/docs/node_deployment.html#multiple-modes
 [docs]: cardano-rosetta-server/README.md
+[standard build instructions]: #build
 [Construction API Documentation]: https://www.rosetta-api.org/docs/construction_api_introduction.html
 [Data API Documentation]: https://www.rosetta-api.org/docs/data_api_introduction.html
 [Cardano Rosetta Docs]: ./docs

--- a/README.md
+++ b/README.md
@@ -100,15 +100,34 @@ Default: `25`
 
 ### Upgrading
 As per the release notes, you **_may_** be required to refresh the state managed by 
-`cardano-db-sync`. This can be achieved without requiring a network re-sync using the following 
-command:
+`cardano-db-sync`. This can be achieved without requiring a network re-sync using one of the two 
+following approached:
 
+#### 1. Apply a Trusted `cardano-db-sync` Snapshot
+Run the build command with the addition of an argument providing a version and network-specific 
+link, sourced from the 
+`cardano-db-sync` [release 
+notes](https://github.com/input-output-hk/cardano-db-sync/releases). For example version 11 on 
+_testnet_, captured at block `3022711`:
+```
+--build-arg SNAPSHOT_URL=https://updates-cardano-testnet.s3.amazonaws.com/cardano-db-sync/11/db-sync-snapshot-schema-11-block-3022711-x86_64.tgz
+```
+... then start a container as per usual.
+
+:information_source: _The snapshot will not be applied if there is no prior `cardano-node` state,
+since the benefit of using the snapshot would be eliminated given `cardano-db-sync` would be
+rolling back to genesis. For best results, ensure the node is close to the network tip prior to
+upgrading._ 
+
+#### 2. Re-sync From Genesis
+A _trustless_ approach to rebuild the DB, by syncing from genesis at the cost of an extended sync 
+duration:
 ```console
 docker stop cardano-rosetta && \
 docker rm cardano-rosetta && \
 docker run --rm -v cardano-rosetta:/data ubuntu rm -rf /data/postgresql /data/db-sync
 ```
-Now create a new container using the run instructions above. Sync progress will be logged by the new container. 
+... then start a container as per usual. Sync progress will be logged by the new container. 
 
 ## Documentation
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -65,7 +65,9 @@ elif [ "$MODE" == "online" ]; then
     else
       echo 'Skipping snapshot restoration as cardano-node will be syncing from genesis';
     fi
-  elif [ ! "$( gosu postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" )" = '1' ]; then
+  fi
+
+  if [ ! "$( gosu postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" )" = '1' ]; then
     echo 'Initializing DB';
     createDb
   fi

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -8,6 +8,10 @@ DATA_DIR_POSTGRES=/data/postgresql
 DATA_DIR_NODE=/data/node-db
 MODE=${MODE:-online}
 
+function createDb {
+  gosu postgres createdb -T template0 --owner="postgres" --encoding=UTF8 "${DB_NAME}"
+}
+
 if [ "$MODE" == "offline" ]; then
   echo 'Cardano Rosetta: Offline Mode';
   exec gosu postgres pm2-runtime start ecosystem.config.js --env production --only 'cardano-rosetta-server'
@@ -33,12 +37,41 @@ elif [ "$MODE" == "online" ]; then
     /ipc
 
   /etc/init.d/postgresql stop 1> /dev/null  && /etc/init.d/postgresql start 1> /dev/null
-  if [ ! "$( gosu postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" )" = '1' ]; then
-    echo 'Initializing PostgreSQL';
-    gosu postgres createdb -T template0 --owner="postgres" --encoding=UTF8 "${DB_NAME}"
+
+  snapshot_count=$(find "/snapshot" -type f -name '*.tgz' | wc -l)
+  node_data_count=$(ls -1 ${DATA_DIR_NODE} | wc -l)
+
+  if test "${snapshot_count}" -gt 0 ; then
+    if test "${node_data_count}" -gt 0; then
+      echo 'Restoring cardano-db-sync snapshot';
+      file_count=$(find "$DATA_DIR_DB_SYNC" -type f -name '*.lstate' | wc -l)
+      if test "${file_count}" -gt 0 ; then
+        echo "Removing existing files from $DATA_DIR_DB_SYNC"
+        rm -f ${DATA_DIR_DB_SYNC}/*.lstate
+      fi
+      tmp_dir=$(gosu postgres mktemp --directory -t db-sync-snapshot-XXXXXXXXXX)
+      echo "Extracting tarball"
+      gosu postgres tar -zxvf /snapshot/*.tgz --directory "$tmp_dir"
+      db_file=$(find "$tmp_dir/" -iname "*.sql")
+      lstate_file=$(find "${tmp_dir}/" -iname "*.lstate")
+      mv "${lstate_file}" "$DATA_DIR_DB_SYNC"
+      echo "Dropping DB $DB_NAME if exists"
+      gosu postgres dropdb --if-exists $DB_NAME
+      echo "Restoring DB from file"
+      createDb
+      gosu postgres psql --dbname="${DB_NAME}" -f "${db_file}"
+      echo 'Cleaning up';
+      rm -r "${tmp_dir}" /snapshot/*
+    else
+      echo 'Skipping snapshot restoration as cardano-node will be syncing from genesis';
+    fi
+  elif [ ! "$( gosu postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" )" = '1' ]; then
+    echo 'Initializing DB';
+    createDb
   fi
 
   /etc/init.d/postgresql stop 1> /dev/null
+  echo 'Starting';
   exec gosu postgres pm2-runtime start ecosystem.config.js --env production
 
 else

--- a/scripts/maybe_download_cardano-db-sync_snapshot.sh
+++ b/scripts/maybe_download_cardano-db-sync_snapshot.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+SNAPSHOT_URL=${1:-}
+WORKING_DIR=${2:-.}
+
+if [[ "${SNAPSHOT_URL}" =~ ^https://.* ]]; then
+  SNAPSHOT_BASENAME="$(basename "${SNAPSHOT_URL}")"
+  cd $WORKING_DIR
+  echo "Downloading snapshot ${SNAPSHOT_URL} ..."
+  curl -LOC - ${SNAPSHOT_URL}
+  echo "Downloading sha256sum ${SNAPSHOT_URL}.sha256sum ..."
+  curl -LO ${SNAPSHOT_URL}.sha256sum
+  echo "Checking sha256sum ..."
+  sha256sum -c ${SNAPSHOT_BASENAME}.sha256sum
+  rm ${SNAPSHOT_BASENAME}.sha256sum
+fi


### PR DESCRIPTION
# Description
Users need the ability to utilise the supplied cardano-db-sync snapshots, to expedite the PostgreSQL sync which would otherwise take many hours. As there is no snapshot of the cardano-node state, the restoration should only proceed if the instance contains some state in the expected directory, otherwise cardano-db-sync will roll back to the node’s tip, or genesis in the case of a new instance, and thus eliminate most benefits of the feature. 

# Proposed Solution
Introduces a build argument to download and store the provided remote snapshot
in the image, plus startup logic to restore unless it's the first run with no `cardano-node` state.

# Testing
At least 3 scenarios should be tested:

1. Instance fully synced, observe no lengthy sync
2. Instance partially synced, observe a proportional sync
3. New instance, observe snapshot not being applied.

