### PR TITLE
Chore/cardano node 1 33 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.7.0](https://github.com/input-output-hk/cardano-rosetta/compare/1.4.0...1.8.0) (2022-01-25)
+
+
+### Features
+* bump cardano-node + GHC version ([23db4c3](https://github.com/input-output-hk/cardano-rosetta/commit/23db4c38ed22e1cd7dbeee01420bb5ff84f0c9f3))
+
 ## [1.6.1](https://github.com/input-output-hk/cardano-rosetta/compare/1.5.0...1.6.1) (2021-12-17)
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN wget --secure-protocol=TLSv1_2 \
   mv cabal /usr/local/bin/
 RUN cabal update
 WORKDIR /app/ghc
-ARG GHC_VERSION=8.10.2
+ARG GHC_VERSION=8.10.7
 RUN wget --secure-protocol=TLSv1_2 \
   https://downloads.haskell.org/~ghc/${GHC_VERSION}/ghc-${GHC_VERSION}-x86_64-deb9-linux.tar.xz &&\
   tar -xf ghc-${GHC_VERSION}-x86_64-deb9-linux.tar.xz &&\
@@ -49,7 +49,7 @@ RUN ./autogen.sh && ./configure && make && make install
 ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 WORKDIR /app/src
-ARG CARDANO_NODE_VERSION=1.31.0
+ARG CARDANO_NODE_VERSION=1.33.0
 RUN git clone https://github.com/input-output-hk/cardano-node.git &&\
   cd cardano-node &&\
   git fetch --all --tags &&\

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ DOCKER_BUILDKIT=1 \
 docker build \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --cache-from=inputoutput/cardano-rosetta:master \
-  -t inputoutput/cardano-rosetta:1.6.1 \
-  https://github.com/input-output-hk/cardano-rosetta.git#1.6.1
+  -t inputoutput/cardano-rosetta:1.7.0 \
+  https://github.com/input-output-hk/cardano-rosetta.git#1.7.0
 ```
 
 </details>
@@ -33,8 +33,8 @@ docker build \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --build-arg NETWORK=testnet \
   --cache-from=inputoutput/cardano-rosetta:master \
-  -t inputoutput/cardano-rosetta:1.6.1-testnet \
-  https://github.com/input-output-hk/cardano-rosetta.git#1.6.1
+  -t inputoutput/cardano-rosetta:1.7.0-testnet \
+  https://github.com/input-output-hk/cardano-rosetta.git#1.7.0
 ```
 
 </details>
@@ -53,7 +53,7 @@ docker run \
   -p 8080:8080 \
   -v cardano-rosetta:/data \
   --shm-size=2g \
-  inputoutput/cardano-rosetta:1.6.1
+  inputoutput/cardano-rosetta:1.7.0
 ```
 
 </details>
@@ -67,7 +67,7 @@ docker run \
   -p 8081:8080 \
   -v cardano-rosetta-testnet:/data \
   --shm-size=2g \
-  inputoutput/cardano-rosetta:1.6.1-testnet
+  inputoutput/cardano-rosetta:1.7.0-testnet
 ```
 
 </details>
@@ -123,8 +123,8 @@ docker build \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --build-arg SNAPSHOT_URL=https://update-cardano-mainnet.iohk.io/cardano-db-sync/12/db-sync-snapshot-schema-12-block-6590499-x86_64.tgz \
   --cache-from=inputoutput/cardano-rosetta:master \
-  -t inputoutput/cardano-rosetta:1.6.1-apply-snapshot \
-  https://github.com/input-output-hk/cardano-rosetta.git#1.6.1
+  -t inputoutput/cardano-rosetta:1.7.0-apply-snapshot \
+  https://github.com/input-output-hk/cardano-rosetta.git#1.7.0
 ```
 
 </details>
@@ -139,8 +139,8 @@ docker build \
   --build-arg NETWORK=testnet \
   --build-arg SNAPSHOT_URL=https://updates-cardano-testnet.s3.amazonaws.com/cardano-db-sync/12/db-sync-snapshot-schema-12-block-3147999-x86_64.tgz \
   --cache-from=inputoutput/cardano-rosetta:master \
-  -t inputoutput/cardano-rosetta:1.6.1-testnet-apply-snapshot \
-  https://github.com/input-output-hk/cardano-rosetta.git#1.6.1
+  -t inputoutput/cardano-rosetta:1.7.0-testnet-apply-snapshot \
+  https://github.com/input-output-hk/cardano-rosetta.git#1.7.0
 ```
 
 </details>
@@ -156,7 +156,7 @@ docker run \
   -p 8080:8080 \
   -v cardano-rosetta:/data \
   --shm-size=2g \
-  inputoutput/cardano-rosetta:1.6.1-apply-snapshot
+  inputoutput/cardano-rosetta:1.7.0-apply-snapshot
 ```
 
 </details>
@@ -170,7 +170,7 @@ docker run \
   -p 8081:8080 \
   -v cardano-rosetta-testnet:/data \
   --shm-size=2g \
-  inputoutput/cardano-rosetta:1.6.1-testnet-apply-snapshot
+  inputoutput/cardano-rosetta:1.7.0-testnet-apply-snapshot
 ```
 
 </details>

--- a/cardano-rosetta-server/package.json
+++ b/cardano-rosetta-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-rosetta-server",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Rosetta API server specification implementation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Description
`cardano-node@1.33.x` contains performance improvements

# Proposed Solution
Bump the version of `cardano-node` only, as `cardano-db-sync@12.0.0` is compatible. 

# Testing
Since `cardano-db-sync` is not changing, our testing here can be limited to a smoke test.
