### PR TITLE
Replace genesis protocol param references to epoch_param table

### DIFF
--- a/cardano-rosetta-server/src/server/controllers/construction-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/construction-controller.ts
@@ -144,8 +144,8 @@ const configure = (
       async () => {
         const networkIdentifier = getNetworkIdentifierByRequestParameters(request.body.network_identifier);
         // eslint-disable-next-line camelcase
-        const relativeTtl = constructionService.calculateRelativeTtl(request.body.metadata?.relative_ttl);
-        const transactionSize = cardanoService.calculateTxSize(
+        const relativeTtl = await constructionService.calculateRelativeTtl(request.body.metadata?.relative_ttl);
+        const transactionSize = await cardanoService.calculateTxSize(
           request.log,
           networkIdentifier,
           request.body.operations,
@@ -194,7 +194,7 @@ const configure = (
         const operations = request.body.operations;
         const networkIdentifier = getNetworkIdentifierByRequestParameters(request.body.network_identifier);
         logger.info(operations, '[constuctionPayloads] Operations about to be processed');
-        const unsignedTransaction = cardanoService.createUnsignedTransaction(
+        const unsignedTransaction = await cardanoService.createUnsignedTransaction(
           logger,
           networkIdentifier,
           operations,

--- a/cardano-rosetta-server/src/server/db/blockchain-repository.ts
+++ b/cardano-rosetta-server/src/server/db/blockchain-repository.ts
@@ -18,7 +18,7 @@ import {
   TotalCount,
   SearchFilters
 } from '../models';
-import { LinearFeeParameters } from '../services/cardano-services';
+import { DepositParameters, LinearFeeParameters } from '../services/cardano-services';
 import {
   hexStringToBuffer,
   hexFormatter,
@@ -108,6 +108,11 @@ export interface BlockchainRepository {
    * Get the lastest minFeeA and minFeeB
    */
   getLinearFeeParameters(logger: Logger): Promise<LinearFeeParameters>;
+
+  /**
+   * Get the lastest deposit parameters
+   */
+  getDepositParameters(logger: Logger): Promise<DepositParameters>;
 
   /**
    * Returns an array containing all utxo for address till block identified by blockIdentifier if present, else the last
@@ -661,6 +666,12 @@ export const configure = (databaseInstance: Pool): BlockchainRepository => ({
     logger.debug('[getLinearFeeParameters] About to run getLinearFeeParameters query');
     const result = await databaseInstance.query(Queries.findLatestMinFeeAAndMinFeeB);
     return { minFeeA: result.rows[0].min_fee_a, minFeeB: result.rows[0].min_fee_b };
+  },
+
+  async getDepositParameters(logger: Logger): Promise<DepositParameters> {
+    logger.debug('[getLinearFeeParameters] About to run findLatestDepositParameters query');
+    const result = await databaseInstance.query(Queries.findLatestDepositParameters);
+    return { keyDeposit: result.rows[0].key_deposit, poolDeposit: result.rows[0].pool_deposit };
   },
 
   async findGenesisBlock(logger: Logger): Promise<GenesisBlock | null> {

--- a/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
+++ b/cardano-rosetta-server/src/server/db/queries/blockchain-queries.ts
@@ -498,6 +498,13 @@ ORDER BY id
 DESC LIMIT 1
 `;
 
+const findLatestDepositParameters = `
+  SELECT 
+    key_deposit, pool_deposit FROM epoch_param  
+  ORDER BY id 
+  DESC LIMIT 1
+`;
+
 const Queries = {
   findBalanceByAddressAndBlock,
   findBlock,
@@ -518,7 +525,8 @@ const Queries = {
   findPoolRetirements,
   findTransactionsOutputs,
   findUtxoByAddressAndBlock,
-  findLatestMinFeeAAndMinFeeB
+  findLatestMinFeeAAndMinFeeB,
+  findLatestDepositParameters
 };
 
 export default Queries;

--- a/cardano-rosetta-server/src/server/index.ts
+++ b/cardano-rosetta-server/src/server/index.ts
@@ -9,18 +9,12 @@ import * as Services from './services/services';
 import * as CardanoCli from './utils/cardano/cli/cardanonode-cli';
 import * as CardanoNode from './utils/cardano/cli/cardano-node';
 import { Environment, parseEnvironment } from './utils/environment-parser';
-import { DepositParameters } from './services/cardano-services';
 
 // FIXME: validate the following paraemeters when implementing (2)
 // https://github.com/input-output-hk/cardano-rosetta/issues/101
 const genesis = JSON.parse(fs.readFileSync(path.resolve(process.env.GENESIS_SHELLEY_PATH)).toString());
 const networkMagic = genesis.networkMagic;
 const networkId = genesis.networkId.toLowerCase();
-
-const depositParameters: DepositParameters = {
-  keyDeposit: genesis.protocolParams.keyDeposit,
-  poolDeposit: genesis.protocolParams.poolDeposit
-};
 
 const start = async (databaseInstance: Pool) => {
   let server;
@@ -36,8 +30,7 @@ const start = async (databaseInstance: Pool) => {
       networkId,
       networkMagic,
       environment.TOPOLOGY_FILE,
-      environment.DEFAULT_RELATIVE_TTL,
-      depositParameters
+      environment.DEFAULT_RELATIVE_TTL
     );
     server = buildServer(services, cardanoCli, cardanoNode, environment.LOGGER_LEVEL, {
       networkId,

--- a/cardano-rosetta-server/src/server/services/services.ts
+++ b/cardano-rosetta-server/src/server/services/services.ts
@@ -21,12 +21,11 @@ export const configure = (
   networkId: string,
   networkMagic: number,
   topologyFile: TopologyConfig,
-  DEFAULT_RELATIVE_TTL: number,
-  depositParameters: DepositParameters
+  DEFAULT_RELATIVE_TTL: number
   // FIXME: we can group networkId and networkMagic in a new type
   // eslint-disable-next-line max-params
 ): Services => {
-  const cardanoServiceInstance = cardanoService(depositParameters);
+  const cardanoServiceInstance = cardanoService(repositories.blockchainRepository);
   const blockServiceInstance = blockService(repositories.blockchainRepository, cardanoServiceInstance);
   return {
     blockService: blockServiceInstance,

--- a/cardano-rosetta-server/src/server/utils/data-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/data-mapper.ts
@@ -136,7 +136,7 @@ const isBlockUtxos = (block: BlockUtxos | BalanceAtBlock): block is BlockUtxos =
  */
 export const mapToRosettaTransaction = (
   transaction: PopulatedTransaction,
-  poolDeposit: number
+  poolDeposit: string
 ): Components.Schemas.Transaction => {
   const status = transaction.validContract ? OperationTypeStatus.SUCCESS : OperationTypeStatus.INVALID;
   const inputsAsOperations = transaction.inputs.map((input, index) =>
@@ -243,7 +243,7 @@ export const mapToRosettaTransaction = (
       },
       metadata: {
         // if this protocol value changes this amount may not be accurate
-        depositAmount: mapAmount(poolDeposit.toString()),
+        depositAmount: mapAmount(poolDeposit),
         poolRegistrationParams: {
           pledge: poolRegistration.pledge,
           rewardAddress: poolRegistration.address,
@@ -327,7 +327,7 @@ export const mapToRosettaTransaction = (
 export const mapToRosettaBlock = (
   block: Block,
   transactions: PopulatedTransaction[],
-  poolDeposit: number
+  poolDeposit: string
 ): Components.Schemas.Block => ({
   block_identifier: {
     hash: block.hash,

--- a/cardano-rosetta-server/src/server/utils/index-mapper.ts
+++ b/cardano-rosetta-server/src/server/utils/index-mapper.ts
@@ -3,7 +3,7 @@ import { mapToRosettaTransaction } from './data-mapper';
 
 export interface SearchTransactionsMapperParameters {
   transactions: PopulatedTransaction[];
-  poolDeposit: number;
+  poolDeposit: string;
   offset: number;
   limit: number;
   totalCount: number;

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -854,6 +854,7 @@ declare namespace Components {
       network_identifier?: /* The network_identifier specifies which network a particular object is associated with. */ NetworkIdentifier;
       transaction_identifier: /* The transaction_identifier uniquely identifies a transaction in a particular network and block or in the mempool. */ TransactionIdentifier;
       direction: /* Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may reference `backward` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if a transaction relation is from child to parent or the reverse. */ Direction;
+      __type?: string;
     }
     export interface Relay {
       type?: string;

--- a/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/account/account-balance-api.test.ts
@@ -38,13 +38,9 @@ const ACCOUNT_BALANCE_ENDPOINT = '/account/balance';
 describe('/account/balance endpoint', () => {
   let database: Pool;
   let server: FastifyInstance;
-  let alonzoDatabase: Pool;
-  let serverWithAlonzoSupport: FastifyInstance;
   beforeAll(async () => {
     database = setupDatabase();
     server = setupServer(database);
-    alonzoDatabase = setupDatabase(process.env.DB_CONNECTION_STRING, 'purple');
-    serverWithAlonzoSupport = setupServer(alonzoDatabase);
   });
 
   afterAll(async () => {

--- a/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-payloads-api.test.ts
@@ -5,7 +5,7 @@ import StatusCodes from 'http-status-codes';
 import { Pool } from 'pg';
 import { FastifyInstance } from 'fastify';
 import {
-  setupOfflineDatabase,
+  setupDatabase,
   setupServer,
   testInvalidNetworkParameters,
   modifyAccount,
@@ -103,7 +103,7 @@ describe(CONSTRUCTION_PAYLOADS_ENDPOINT, () => {
   let server: FastifyInstance;
 
   beforeAll(async () => {
-    database = setupOfflineDatabase();
+    database = setupDatabase();
     server = setupServer(database);
   });
 
@@ -763,7 +763,7 @@ describe('Invalid request with MultiAssets', () => {
   let server: FastifyInstance;
 
   beforeAll(async () => {
-    database = setupOfflineDatabase();
+    database = setupDatabase();
     server = setupServer(database);
   });
 
@@ -897,7 +897,7 @@ describe('Pool Registration', () => {
   let server: FastifyInstance;
 
   beforeAll(async () => {
-    database = setupOfflineDatabase();
+    database = setupDatabase();
     server = setupServer(database);
   });
 
@@ -1654,7 +1654,7 @@ describe('Pool Registration with certification', () => {
   let server: FastifyInstance;
 
   beforeAll(async () => {
-    database = setupOfflineDatabase();
+    database = setupDatabase();
     server = setupServer(database);
   });
 
@@ -1739,7 +1739,7 @@ describe('Vote Registration', () => {
   let server: FastifyInstance;
 
   beforeAll(async () => {
-    database = setupOfflineDatabase();
+    database = setupDatabase();
     server = setupServer(database);
   });
 

--- a/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-preprocess-api.test.ts
@@ -51,12 +51,7 @@ import {
   CONSTRUCTION_PAYLOADS_WITH_POOL_RETIREMENT,
   SIGNED_TX_WITH_POOL_RETIREMENT
 } from '../fixture-data';
-import {
-  modifyMAOperation,
-  setupOfflineDatabase,
-  setupServer,
-  testInvalidNetworkParameters
-} from '../utils/test-utils';
+import { modifyMAOperation, setupDatabase, setupServer, testInvalidNetworkParameters } from '../utils/test-utils';
 
 const CONSTRUCTION_PREPROCESS_ENDPOINT = '/construction/preprocess';
 
@@ -92,7 +87,7 @@ describe(CONSTRUCTION_PREPROCESS_ENDPOINT, () => {
   let server: FastifyInstance;
 
   beforeAll(async () => {
-    database = setupOfflineDatabase();
+    database = setupDatabase();
     server = setupServer(database);
   });
 

--- a/cardano-rosetta-server/test/e2e/utils/test-utils.ts
+++ b/cardano-rosetta-server/test/e2e/utils/test-utils.ts
@@ -50,7 +50,6 @@ export const minKeyDeposit = 2000000;
 export const poolDeposit = 500000000;
 
 export const linearFeeParameters = { minFeeA: 44, minFeeB: 155381 };
-export const depositParameters = { keyDeposit: minKeyDeposit, poolDeposit };
 const NETWORK_ID = 'mainnet';
 
 export const setupServer = (database: Pool, disableSearchApi = false): FastifyInstance => {
@@ -62,8 +61,7 @@ export const setupServer = (database: Pool, disableSearchApi = false): FastifyIn
     // eslint-disable-next-line no-magic-numbers
     1097911063,
     JSON.parse(fs.readFileSync(path.resolve(process.env.TOPOLOGY_FILE_PATH)).toString()),
-    Number(process.env.DEFAULT_RELATIVE_TTL),
-    depositParameters
+    Number(process.env.DEFAULT_RELATIVE_TTL)
   );
   return buildServer(services, cardanoCliMock, cardanoNodeMock, process.env.LOGGER_LEVEL, {
     networkId: NETWORK_ID,

--- a/cardano-rosetta-server/test/unit/services/cardano-services.test.ts
+++ b/cardano-rosetta-server/test/unit/services/cardano-services.test.ts
@@ -1,13 +1,24 @@
+import { Pool } from 'pg';
+import * as BlockchainRepository from '../../../src/server/db/blockchain-repository';
 import configure, { CardanoService } from '../../../src/server/services/cardano-services';
 import { EraAddressType } from '../../../src/server/utils/constants';
+import { setupDatabase } from '../../e2e/utils/test-utils';
 const minKeyDeposit = 2000000;
 const poolDeposit = 500000000;
 
 describe('Cardano Service', () => {
+  let database: Pool;
+  let blockchainRepository: BlockchainRepository.BlockchainRepository;
   let cardanoService: CardanoService;
 
   beforeAll(() => {
-    cardanoService = configure({ keyDeposit: minKeyDeposit, poolDeposit });
+    database = setupDatabase();
+    blockchainRepository = BlockchainRepository.configure(database);
+    cardanoService = configure(blockchainRepository);
+  });
+
+  afterAll(async () => {
+    await database.end();
   });
 
   describe('Address type detection', () => {


### PR DESCRIPTION
# Description

The current implementation uses the genesis file for fee and deposit parameters, which works for now since those values have not been updated, but the epoch_param table contains the active values based on the epoch and should be used instead. 

# Proposed Solution

Add new method to query for Deposit Parameters at `BlockchainRepository`.
Replace `BlockchainRepository` per `DepositParameters` in  `CardanoService` dependencies in order to query deposit parameters dinamically


