### PR TITLE
fix: validate type of  metadata field for vote registrations

### DIFF
--- a/cardano-rosetta-server/src/server/db/blockchain-repository.ts
+++ b/cardano-rosetta-server/src/server/db/blockchain-repository.ts
@@ -380,21 +380,23 @@ const parsePoolRetirementRow = (
 const parseVoteRow = (transaction: PopulatedTransaction, metadata: FindTransactionMetadata): PopulatedTransaction => {
   const { data, signature } = metadata;
   if (isVoteDataValid(data) && isVoteSignatureValid(signature)) {
-    const votingKey = remove0xPrefix(data[CatalystDataIndexes.VOTING_KEY]);
-    const stakeKey = remove0xPrefix(data[CatalystDataIndexes.STAKE_KEY]);
-    const rewardAddress = getAddressFromHexString(remove0xPrefix(data[CatalystDataIndexes.REWARD_ADDRESS])).to_bech32();
-    const votingNonce = data[CatalystDataIndexes.VOTING_NONCE];
-    const votingSignature = remove0xPrefix(signature[CatalystSigIndexes.VOTING_SIGNATURE]);
-    return {
-      ...transaction,
-      voteRegistrations: transaction.voteRegistrations.concat({
-        votingKey,
-        stakeKey,
-        rewardAddress,
-        votingNonce,
-        votingSignature
-      })
-    };
+    const rewardAddress = getAddressFromHexString(remove0xPrefix(data[CatalystDataIndexes.REWARD_ADDRESS]));
+    if (rewardAddress !== undefined) {
+      const votingKey = remove0xPrefix(data[CatalystDataIndexes.VOTING_KEY]);
+      const stakeKey = remove0xPrefix(data[CatalystDataIndexes.STAKE_KEY]);
+      const votingNonce = data[CatalystDataIndexes.VOTING_NONCE];
+      const votingSignature = remove0xPrefix(signature[CatalystSigIndexes.VOTING_SIGNATURE]);
+      return {
+        ...transaction,
+        voteRegistrations: transaction.voteRegistrations.concat({
+          votingKey,
+          stakeKey,
+          rewardAddress: rewardAddress.to_bech32(),
+          votingNonce,
+          votingSignature
+        })
+      };
+    }
   }
   return transaction;
 };

--- a/cardano-rosetta-server/src/server/utils/cardano/addresses.ts
+++ b/cardano-rosetta-server/src/server/utils/cardano/addresses.ts
@@ -122,11 +122,18 @@ export const parseToRewardAddress = (address: string): CardanoWasm.RewardAddress
 };
 
 /**
- * Returns Address type from hex string
+ * Returns Address type if given string is a valid address
+ * otherwise will return undefined
  * @param hex address as hex string
  */
-export const getAddressFromHexString = (hex: string): Address => Address.from_bytes(hexStringToBuffer(hex));
-
+export const getAddressFromHexString = (hex: string): Address | undefined => {
+  try {
+    return Address.from_bytes(hexStringToBuffer(hex));
+  } catch {
+    // eslint-disable-next-line consistent-return
+    return undefined;
+  }
+};
 /**
  * Returns true if the address's prefix belongs to stake address
  * @param address bench 32 address

--- a/cardano-rosetta-server/src/server/utils/cardano/transactions-processor.ts
+++ b/cardano-rosetta-server/src/server/utils/cardano/transactions-processor.ts
@@ -424,6 +424,9 @@ const parseVoteMetadataToOperation = (
   const dataParsed = JSON.parse(dataJson);
   const sigParsed = JSON.parse(sigJson);
 
+  const rewardAddress = getAddressFromHexString(remove0xPrefix(dataParsed[CatalystDataIndexes.REWARD_ADDRESS]));
+  if (rewardAddress === undefined) throw ErrorFactory.invalidAddressError();
+
   const parsedMetadata: Components.Schemas.VoteRegistrationMetadata = {
     votingKey: {
       hex_bytes: remove0xPrefix(dataParsed[CatalystDataIndexes.VOTING_KEY]),
@@ -433,7 +436,7 @@ const parseVoteMetadataToOperation = (
       hex_bytes: remove0xPrefix(dataParsed[CatalystDataIndexes.STAKE_KEY]),
       curve_type: CurveType.edwards25519
     },
-    rewardAddress: getAddressFromHexString(remove0xPrefix(dataParsed[CatalystDataIndexes.REWARD_ADDRESS])).to_bech32(),
+    rewardAddress: rewardAddress.to_bech32(),
     votingNonce: dataParsed[CatalystDataIndexes.VOTING_NONCE],
     votingSignature: remove0xPrefix(sigParsed[CatalystSigIndexes.VOTING_SIGNATURE])
   };

--- a/cardano-rosetta-server/src/server/utils/validations.ts
+++ b/cardano-rosetta-server/src/server/utils/validations.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import {
   PUBLIC_KEY_BYTES_LENGTH,
   ADA,
@@ -60,16 +61,32 @@ export const isEd25519Signature = (hash: string): boolean => {
   return !!ed25519Signature;
 };
 
-export const isVoteDataValid = (jsonObject: any): boolean => {
-  const isObject = typeof jsonObject === 'object';
-  const dataIndexes = Object.keys(CatalystDataIndexes).filter(key => parseInt(key) > 0);
-  return isObject && dataIndexes.every(index => index in jsonObject);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isHexString = (value: any) => typeof value === 'string' && new RegExp('^(0x)?[0-9a-fA-F]+$').test(value);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const validateVoteDataFields = (object: any) => {
+  const hexStringIndexes = [
+    CatalystDataIndexes.REWARD_ADDRESS,
+    CatalystDataIndexes.STAKE_KEY,
+    CatalystDataIndexes.VOTING_KEY
+  ];
+  const isValidVotingNonce =
+    object[CatalystDataIndexes.VOTING_NONCE] && !Number.isNaN(object[CatalystDataIndexes.VOTING_NONCE]);
+  return isValidVotingNonce && hexStringIndexes.every(index => index in object && isHexString(object[index]));
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isVoteDataValid = (jsonObject: any): boolean => {
+  const isObject = typeof jsonObject === 'object';
+  return isObject && validateVoteDataFields(jsonObject);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isVoteSignatureValid = (jsonObject: any): boolean => {
   const isObject = typeof jsonObject === 'object';
   const dataIndexes = Object.keys(CatalystSigIndexes).filter(key => parseInt(key) > 0);
-  return isObject && dataIndexes.every(index => index in jsonObject);
+  return isObject && dataIndexes.every(index => index in jsonObject && isHexString(jsonObject[index]));
 };
 
 const validateStatus = (status: string): void => {

--- a/cardano-rosetta-server/test/unit/utils/cardano/addresses.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/cardano/addresses.test.ts
@@ -1,0 +1,16 @@
+import { getAddressFromHexString } from '../../../../src/server/utils/cardano/addresses';
+import { Address } from 'cardano-serialization-lib';
+
+describe('Addresses', () => {
+  describe('getAddressFromHexString', () => {
+    it('return an Address from a valid hex string', () => {
+      const validAddress =
+        '01663f13971437b6e2f09771c06534c4ffd95950ac94390f34e091b5ba8cc49dce93335c74cb3aaf8e0f7eacb8813ae4a107383ee7649985e6';
+      expect(getAddressFromHexString(validAddress)).toBeInstanceOf(Address);
+    });
+    it('return undefined from a hex string that does not represent an Address', () => {
+      const validAddress = 'fff';
+      expect(getAddressFromHexString(validAddress)).toEqual(undefined);
+    });
+  });
+});

--- a/cardano-rosetta-server/test/unit/utils/validations.test.ts
+++ b/cardano-rosetta-server/test/unit/utils/validations.test.ts
@@ -1,0 +1,83 @@
+import { isVoteDataValid, isVoteSignatureValid } from '../../../src/server/utils/validations';
+
+describe('Validations', () => {
+  describe('isVoteDataValid', () => {
+    it('true when vote data metadata format is valid', () => {
+      const validDataLabel = {
+        '1': '0x8bcec4282239b2cc1a7d8bb294c154c849fc200c7ebd27ef45e610d849bc302a',
+        '2': '0x56f29f391a3bb5ff90637b2d2d0a32590214871284b0577e4671b0c1a83f79ba',
+        '3':
+          '0x01663f13971437b6e2f09771c06534c4ffd95950ac94390f34e091b5ba8cc49dce93335c74cb3aaf8e0f7eacb8813ae4a107383ee7649985e6',
+        '4': 26912766
+      };
+      expect(isVoteDataValid(validDataLabel)).toEqual(true);
+    });
+    it('true when vote data metadata format is valid besides hex string does not start with 0x', () => {
+      const validDataLabel = {
+        '1': '8bcec4282239b2cc1a7d8bb294c154c849fc200c7ebd27ef45e610d849bc302a',
+        '2': '56f29f391a3bb5ff90637b2d2d0a32590214871284b0577e4671b0c1a83f79ba',
+        '3':
+          '01663f13971437b6e2f09771c06534c4ffd95950ac94390f34e091b5ba8cc49dce93335c74cb3aaf8e0f7eacb8813ae4a107383ee7649985e6',
+        '4': 26912766
+      };
+      expect(isVoteDataValid(validDataLabel)).toEqual(true);
+    });
+    it('falsy when there are missing fields', () => {
+      const missingFieldsDataLabel = {
+        '1': '0x8bcec4282239b2cc1a7d8bb294c154c849fc200c7ebd27ef45e610d849bc302a',
+        '2': '0x56f29f391a3bb5ff90637b2d2d0a32590214871284b0577e4671b0c1a83f79ba',
+        '4': 26912766
+      };
+      expect(isVoteDataValid(missingFieldsDataLabel)).toBeFalsy;
+    });
+    it('false when expected hex string has invalid format', () => {
+      const invalidHexStringDataLabel = {
+        '1': '0x8bcec4282239b2cc1a7d8bb294c154c849fc200c7ebd27ef45e610d849bc302a',
+        '2': 'thisIsNotAHexString',
+        '3':
+          '0x01663f13971437b6e2f09771c06534c4ffd95950ac94390f34e091b5ba8cc49dce93335c74cb3aaf8e0f7eacb8813ae4a107383ee7649985e6',
+        '4': 26912766
+      };
+      expect(isVoteDataValid(invalidHexStringDataLabel)).toEqual(false);
+    });
+    it('false when expected number has invalid format', () => {
+      const invalidNumberDataLabel = {
+        '1': '0x8bcec4282239b2cc1a7d8bb294c154c849fc200c7ebd27ef45e610d849bc302a',
+        '2': 'thisIsNotAHexString',
+        '3':
+          '0x01663f13971437b6e2f09771c06534c4ffd95950ac94390f34e091b5ba8cc49dce93335c74cb3aaf8e0f7eacb8813ae4a107383ee7649985e6',
+        '4': 'NaN'
+      };
+      expect(isVoteDataValid(invalidNumberDataLabel)).toEqual(false);
+    });
+  });
+  describe('isVoteSignatureValid', () => {
+    it('true when vote signature metadata format is valid', () => {
+      const validSignatureLabel = {
+        '1':
+          '0xf75f7a54a79352f9d0e2c4de4e8ded8ae9304fa0f3b021754f8d149c90c7b01e1c6bbfdd623c294d82f5e5cbbfc0bd6fd1c674780db4025446e2eafc87f61b0a'
+      };
+      expect(isVoteSignatureValid(validSignatureLabel)).toEqual(true);
+    });
+    it('true when vote signature label format is valid besides hex string does not start with 0x', () => {
+      const validSignatureLabel = {
+        '1':
+          'f75f7a54a79352f9d0e2c4de4e8ded8ae9304fa0f3b021754f8d149c90c7b01e1c6bbfdd623c294d82f5e5cbbfc0bd6fd1c674780db4025446e2eafc87f61b0a'
+      };
+      expect(isVoteSignatureValid(validSignatureLabel)).toEqual(true);
+    });
+    it('falsy when there is a missing field', () => {
+      const invalidSignatureLabel = {
+        '2':
+          '0xf75f7a54a79352f9d0e2c4de4e8ded8ae9304fa0f3b021754f8d149c90c7b01e1c6bbfdd623c294d82f5e5cbbfc0bd6fd1c674780db4025446e2eafc87f61b0a'
+      };
+      expect(isVoteSignatureValid(invalidSignatureLabel)).toBeFalsy;
+    });
+    it('false when expected hex string has invalid format', () => {
+      const invalidSignatureLabel = {
+        '1': 'thisIsNotAHexString'
+      };
+      expect(isVoteSignatureValid(invalidSignatureLabel)).toEqual(false);
+    });
+  });
+});


### PR DESCRIPTION
# Description

Improve metadata handling for vote registration labels. There was a missig check that made cases such as https://testnet.cardanoscan.io/transaction/c9ad03f41fd36996a8b8588ee21fd95acb0f4e784a554724f0776306f8358042 to get into an error due to invalid expected format

# Proposed Solution

Add validation for metadata vote registration fields. Check for fields to be hex strings

# Important Changes Introduced

N/A

