### PR TITLE
Cardano Node 1.35.0 and Cardano Db Sync 13.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ WORKDIR /app/src/secp256k1
 RUN ./autogen.sh && ./configure --enable-module-schnorrsig --enable-experimental &&\
     make && make install
 WORKDIR /app/src
-ARG CARDANO_NODE_VERSION=1.35.0-rc2
+ARG CARDANO_NODE_VERSION=1.35.0
 RUN git clone https://github.com/input-output-hk/cardano-node.git &&\
   cd cardano-node &&\
   git fetch --all --tags &&\
@@ -71,7 +71,7 @@ RUN cabal install cardano-cli \
   --installdir=/usr/local/bin \
   -f -systemd
 WORKDIR /app/src
-ARG CARDANO_DB_SYNC_VERSION=13.0.0-rc2
+ARG CARDANO_DB_SYNC_VERSION=13.0.0
 RUN git clone https://github.com/input-output-hk/cardano-db-sync.git &&\
   cd cardano-db-sync &&\
   git fetch --all --tags &&\

--- a/cardano-rosetta-server/docker-compose.yml
+++ b/cardano-rosetta-server/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         max-size: "200k"
         max-file: "10"
   cardano-node:
-    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.35.0-rc2}
+    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.35.0}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     volumes:
@@ -34,7 +34,7 @@ services:
         max-size: "400k"
         max-file: "20"
   cardano-db-sync:
-    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.0.0-rc2}
+    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.0.0}
     command: [
       "--config", "/config/cardano-db-sync/config.json",
       "--socket-path", "/node-ipc/node.socket"

--- a/test/check/configuration/data/vasil-qa_sample.json
+++ b/test/check/configuration/data/vasil-qa_sample.json
@@ -1,9 +1,9 @@
 {
     "online_url": "http://localhost:8080",
     "data": {
+      "start_index":  1,
       "end_conditions": {
-        "tip": true,
-        "coverage": 0.95
+        "index": 10000
       }
     },
     "network": {


### PR DESCRIPTION
# Description

Bumps Cardano Node and Cardano Db Sync to latest versions.
Also, updates deprecated configuration file to run check:data script for `vasil-dev/vasil-qa` network

