### PR TITLE
fix(searchTransactions): fix on search by addresses and coins

### DIFF
--- a/cardano-rosetta-server/test/e2e/fixture-data.ts
+++ b/cardano-rosetta-server/test/e2e/fixture-data.ts
@@ -7468,6 +7468,416 @@ export const searchTxsWithCoinAndInvalidFilters = [
   }
 ];
 
+export const searchTxByAddressWithInputs = [
+  {
+    block_identifier: {
+      hash: '57e16e0bf74356f949d6d7a06f33f031283c81887233d33c76692790e8137e7f',
+      index: 31322
+    },
+    transaction: {
+      metadata: {
+        scriptSize: 0,
+        size: 216
+      },
+      operations: [
+        {
+          account: {
+            address:
+              'DdzFFzCqrhsje6fw2vbCiDkkgUAs8oMhqH4VkFdiPGGJNo28gbXEXqJ2igZYqnA4Zk3H7b9Wd8iPXnCqPuRDj7Npz4Rx6tVNMZuDSoxk'
+          },
+          amount: {
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            },
+            value: '-684988315368'
+          },
+          coin_change: {
+            coin_action: 'coin_spent',
+            coin_identifier: {
+              identifier: '96ce9dd0565d2d255925dc33461488c8d3bcbca0622616a3cf87bbe9248ca6df:0'
+            }
+          },
+          operation_identifier: {
+            index: 0
+          },
+          status: 'success',
+          type: 'input'
+        },
+        {
+          account: {
+            address:
+              'DdzFFzCqrhsiHvdrwXtzmLzJb8yp1qY7nVR5FkwdEQoaPZSYLf6K9BzbDG1vQsp3gdyHGFN6ST3eL6MkKZmGGhVoA9F6G859gPdtC14d'
+          },
+          amount: {
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            },
+            value: '684987144298'
+          },
+          coin_change: {
+            coin_action: 'coin_created',
+            coin_identifier: {
+              identifier: '20e1d2343cbe16ab4b02c57ab17fa99d9a562af57a82dc562f48ee170f866f16:0'
+            }
+          },
+          operation_identifier: {
+            index: 1,
+            network_index: 0
+          },
+          related_operations: [
+            {
+              index: 0
+            }
+          ],
+          status: 'success',
+          type: 'output'
+        },
+        {
+          account: {
+            address:
+              'DdzFFzCqrht7kRa3H83VGtMagziigeStH1CgywX5VsKoRhveG9bHXbJdZWbsrbh2GSfoqJtUNMQvjcaGyXmEnPRta7EGHr5oyMmUayuM'
+          },
+          amount: {
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            },
+            value: '1000000'
+          },
+          coin_change: {
+            coin_action: 'coin_created',
+            coin_identifier: {
+              identifier: '20e1d2343cbe16ab4b02c57ab17fa99d9a562af57a82dc562f48ee170f866f16:1'
+            }
+          },
+          operation_identifier: {
+            index: 2,
+            network_index: 1
+          },
+          related_operations: [
+            {
+              index: 0
+            }
+          ],
+          status: 'success',
+          type: 'output'
+        }
+      ],
+      transaction_identifier: {
+        hash: '20e1d2343cbe16ab4b02c57ab17fa99d9a562af57a82dc562f48ee170f866f16'
+      }
+    }
+  },
+  {
+    block_identifier: {
+      hash: 'c779a8dd67b482c43881258686024d998c08bc94b3c4e39919665b3e4c6dc36d',
+      index: 29556
+    },
+    transaction: {
+      metadata: {
+        scriptSize: 0,
+        size: 220
+      },
+      operations: [
+        {
+          account: {
+            address:
+              'DdzFFzCqrht61X549z7YfhvyBsGKLn21AzatXMnrpL4YYHcXuwBmXFNi2RzjgZQW3kotv1GwjNNRgWbsPSmLuMD4DMX9zARubmdaLYjh'
+          },
+          amount: {
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            },
+            value: '-704988486614'
+          },
+          coin_change: {
+            coin_action: 'coin_spent',
+            coin_identifier: {
+              identifier: '654b1fb68a4f54cc0e64cf1e0e2461573cb4cc95b5cd09692a8f3b0ec4fac383:0'
+            }
+          },
+          operation_identifier: {
+            index: 0
+          },
+          status: 'success',
+          type: 'input'
+        },
+        {
+          account: {
+            address:
+              'DdzFFzCqrhsje6fw2vbCiDkkgUAs8oMhqH4VkFdiPGGJNo28gbXEXqJ2igZYqnA4Zk3H7b9Wd8iPXnCqPuRDj7Npz4Rx6tVNMZuDSoxk'
+          },
+          amount: {
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            },
+            value: '684988315368'
+          },
+          coin_change: {
+            coin_action: 'coin_created',
+            coin_identifier: {
+              identifier: '96ce9dd0565d2d255925dc33461488c8d3bcbca0622616a3cf87bbe9248ca6df:0'
+            }
+          },
+          operation_identifier: {
+            index: 1,
+            network_index: 0
+          },
+          related_operations: [
+            {
+              index: 0
+            }
+          ],
+          status: 'success',
+          type: 'output'
+        },
+        {
+          account: {
+            address:
+              'DdzFFzCqrht13mgsdsfXzJJxCjeEcbwQ4HJCm3mUhxfHAgFRGCnQo2r13mLzEEGJBYu1AXkkGbDx7ADb2hyUfyGv41z7R2CYuejp3gQX'
+          },
+          amount: {
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            },
+            value: '20000000000'
+          },
+          coin_change: {
+            coin_action: 'coin_created',
+            coin_identifier: {
+              identifier: '96ce9dd0565d2d255925dc33461488c8d3bcbca0622616a3cf87bbe9248ca6df:1'
+            }
+          },
+          operation_identifier: {
+            index: 2,
+            network_index: 1
+          },
+          related_operations: [
+            {
+              index: 0
+            }
+          ],
+          status: 'success',
+          type: 'output'
+        }
+      ],
+      transaction_identifier: {
+        hash: '96ce9dd0565d2d255925dc33461488c8d3bcbca0622616a3cf87bbe9248ca6df'
+      }
+    }
+  }
+];
+
+export const searchTxWithCoinSpent = [
+  {
+    block_identifier: {
+      hash: '57e16e0bf74356f949d6d7a06f33f031283c81887233d33c76692790e8137e7f',
+      index: 31322
+    },
+    transaction: {
+      metadata: {
+        scriptSize: 0,
+        size: 216
+      },
+      operations: [
+        {
+          account: {
+            address:
+              'DdzFFzCqrhsje6fw2vbCiDkkgUAs8oMhqH4VkFdiPGGJNo28gbXEXqJ2igZYqnA4Zk3H7b9Wd8iPXnCqPuRDj7Npz4Rx6tVNMZuDSoxk'
+          },
+          amount: {
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            },
+            value: '-684988315368'
+          },
+          coin_change: {
+            coin_action: 'coin_spent',
+            coin_identifier: {
+              identifier: '96ce9dd0565d2d255925dc33461488c8d3bcbca0622616a3cf87bbe9248ca6df:0'
+            }
+          },
+          operation_identifier: {
+            index: 0
+          },
+          status: 'success',
+          type: 'input'
+        },
+        {
+          account: {
+            address:
+              'DdzFFzCqrhsiHvdrwXtzmLzJb8yp1qY7nVR5FkwdEQoaPZSYLf6K9BzbDG1vQsp3gdyHGFN6ST3eL6MkKZmGGhVoA9F6G859gPdtC14d'
+          },
+          amount: {
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            },
+            value: '684987144298'
+          },
+          coin_change: {
+            coin_action: 'coin_created',
+            coin_identifier: {
+              identifier: '20e1d2343cbe16ab4b02c57ab17fa99d9a562af57a82dc562f48ee170f866f16:0'
+            }
+          },
+          operation_identifier: {
+            index: 1,
+            network_index: 0
+          },
+          related_operations: [
+            {
+              index: 0
+            }
+          ],
+          status: 'success',
+          type: 'output'
+        },
+        {
+          account: {
+            address:
+              'DdzFFzCqrht7kRa3H83VGtMagziigeStH1CgywX5VsKoRhveG9bHXbJdZWbsrbh2GSfoqJtUNMQvjcaGyXmEnPRta7EGHr5oyMmUayuM'
+          },
+          amount: {
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            },
+            value: '1000000'
+          },
+          coin_change: {
+            coin_action: 'coin_created',
+            coin_identifier: {
+              identifier: '20e1d2343cbe16ab4b02c57ab17fa99d9a562af57a82dc562f48ee170f866f16:1'
+            }
+          },
+          operation_identifier: {
+            index: 2,
+            network_index: 1
+          },
+          related_operations: [
+            {
+              index: 0
+            }
+          ],
+          status: 'success',
+          type: 'output'
+        }
+      ],
+      transaction_identifier: {
+        hash: '20e1d2343cbe16ab4b02c57ab17fa99d9a562af57a82dc562f48ee170f866f16'
+      }
+    }
+  },
+  {
+    block_identifier: {
+      hash: 'c779a8dd67b482c43881258686024d998c08bc94b3c4e39919665b3e4c6dc36d',
+      index: 29556
+    },
+    transaction: {
+      metadata: {
+        scriptSize: 0,
+        size: 220
+      },
+      operations: [
+        {
+          account: {
+            address:
+              'DdzFFzCqrht61X549z7YfhvyBsGKLn21AzatXMnrpL4YYHcXuwBmXFNi2RzjgZQW3kotv1GwjNNRgWbsPSmLuMD4DMX9zARubmdaLYjh'
+          },
+          amount: {
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            },
+            value: '-704988486614'
+          },
+          coin_change: {
+            coin_action: 'coin_spent',
+            coin_identifier: {
+              identifier: '654b1fb68a4f54cc0e64cf1e0e2461573cb4cc95b5cd09692a8f3b0ec4fac383:0'
+            }
+          },
+          operation_identifier: {
+            index: 0
+          },
+          status: 'success',
+          type: 'input'
+        },
+        {
+          account: {
+            address:
+              'DdzFFzCqrhsje6fw2vbCiDkkgUAs8oMhqH4VkFdiPGGJNo28gbXEXqJ2igZYqnA4Zk3H7b9Wd8iPXnCqPuRDj7Npz4Rx6tVNMZuDSoxk'
+          },
+          amount: {
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            },
+            value: '684988315368'
+          },
+          coin_change: {
+            coin_action: 'coin_created',
+            coin_identifier: {
+              identifier: '96ce9dd0565d2d255925dc33461488c8d3bcbca0622616a3cf87bbe9248ca6df:0'
+            }
+          },
+          operation_identifier: {
+            index: 1,
+            network_index: 0
+          },
+          related_operations: [
+            {
+              index: 0
+            }
+          ],
+          status: 'success',
+          type: 'output'
+        },
+        {
+          account: {
+            address:
+              'DdzFFzCqrht13mgsdsfXzJJxCjeEcbwQ4HJCm3mUhxfHAgFRGCnQo2r13mLzEEGJBYu1AXkkGbDx7ADb2hyUfyGv41z7R2CYuejp3gQX'
+          },
+          amount: {
+            currency: {
+              decimals: 6,
+              symbol: 'ADA'
+            },
+            value: '20000000000'
+          },
+          coin_change: {
+            coin_action: 'coin_created',
+            coin_identifier: {
+              identifier: '96ce9dd0565d2d255925dc33461488c8d3bcbca0622616a3cf87bbe9248ca6df:1'
+            }
+          },
+          operation_identifier: {
+            index: 2,
+            network_index: 1
+          },
+          related_operations: [
+            {
+              index: 0
+            }
+          ],
+          status: 'success',
+          type: 'output'
+        }
+      ],
+      transaction_identifier: {
+        hash: '96ce9dd0565d2d255925dc33461488c8d3bcbca0622616a3cf87bbe9248ca6df'
+      }
+    }
+  }
+];
+
 export const searchWithCurrencyFilter = [
   {
     block_identifier: {

--- a/cardano-rosetta-server/test/e2e/search/search-transactions-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/search/search-transactions-api.test.ts
@@ -10,9 +10,7 @@ import {
   searchTxsWithNoFiltersMaxBlock,
   searchTxWithCoinFilter,
   searchLastTxWithNoFilters,
-  searchNotSucceededTx,
   searchFilteredByTxHash,
-  searchTxsWithCoinAndInvalidFilters,
   searchWithCurrencyFilter,
   searchTxWithAddressFilter,
   searchTxWithStakeAddressFilter,
@@ -50,7 +48,9 @@ import {
   searchTxWithCoinDelegationFilters,
   searchTxWithCoinDeregistrationFilters,
   searchTxsWithCoinStakeRegistrationFilters,
-  searchTxComposedWithdrawal
+  searchTxComposedWithdrawal,
+  searchTxByAddressWithInputs,
+  searchTxWithCoinSpent
 } from '../fixture-data';
 
 const SEARCH_TRANSACTIONS_ENDPOINT = '/search/transactions';
@@ -424,6 +424,22 @@ describe('/search/transactions endpoint', () => {
         total_count: 1
       });
     });
+    test('Should return transactions where the coin was created and spent', async () => {
+      const response = await server.inject({
+        method: 'post',
+        url: SEARCH_TRANSACTIONS_ENDPOINT,
+        payload: generateSearchTransactionsPayload(CARDANO, MAINNET, {
+          coinIdentifier: '96ce9dd0565d2d255925dc33461488c8d3bcbca0622616a3cf87bbe9248ca6df:0',
+          limit: 2,
+          operator: OR_OPERATOR
+        })
+      });
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      expect(response.json()).toEqual({
+        transactions: searchTxWithCoinSpent,
+        total_count: 2
+      });
+    });
     test('Should throw an error when given coin is bad formed', async () => {
       const response = await server.inject({
         method: 'post',
@@ -656,6 +672,21 @@ describe('/search/transactions endpoint', () => {
       expect(response.statusCode).toEqual(StatusCodes.OK);
       expect(response.json()).toEqual({
         transactions: searchTxWithAddressFilter,
+        total_count: 2
+      });
+    });
+    test('Should return txs where the address received and spent funds', async () => {
+      const response = await server.inject({
+        method: 'post',
+        url: SEARCH_TRANSACTIONS_ENDPOINT,
+        payload: generateSearchTransactionsPayload(CARDANO, MAINNET, {
+          address:
+            'DdzFFzCqrhsje6fw2vbCiDkkgUAs8oMhqH4VkFdiPGGJNo28gbXEXqJ2igZYqnA4Zk3H7b9Wd8iPXnCqPuRDj7Npz4Rx6tVNMZuDSoxk'
+        })
+      });
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      expect(response.json()).toEqual({
+        transactions: searchTxByAddressWithInputs,
         total_count: 2
       });
     });
@@ -1427,7 +1458,7 @@ describe('/search/transactions endpoint', () => {
         total_count: 1
       });
     });
-    test('Should return transactions with input type, max block, coin, success and address filters', async () => {
+    test(' Should return transactions with input type, max block, coin, success and address filters ', async () => {
       const response = await server.inject({
         method: 'post',
         url: SEARCH_TRANSACTIONS_ENDPOINT,
@@ -1837,7 +1868,7 @@ describe('/search/transactions endpoint', () => {
       expect(response.statusCode).toEqual(StatusCodes.OK);
       expect(response.json()).toEqual({
         transactions: searchTxsWithAllFiltersAndInputsOrOperator,
-        total_count: 18420,
+        total_count: 18421,
         next_offset: 2
       });
     });
@@ -1860,7 +1891,7 @@ describe('/search/transactions endpoint', () => {
       expect(response.statusCode).toEqual(StatusCodes.OK);
       expect(response.json()).toEqual({
         transactions: searchTxsWithAllFiltersAndInputsOrOperator,
-        total_count: 18420,
+        total_count: 18421,
         next_offset: 2
       });
     });
@@ -1883,7 +1914,7 @@ describe('/search/transactions endpoint', () => {
       expect(response.statusCode).toEqual(StatusCodes.OK);
       expect(response.json()).toEqual({
         transactions: searchTxsWithAllFiltersPoolRegistrationOrOperator,
-        total_count: 4,
+        total_count: 8,
         next_offset: 2
       });
     });
@@ -1906,7 +1937,7 @@ describe('/search/transactions endpoint', () => {
       expect(response.statusCode).toEqual(StatusCodes.OK);
       expect(response.json()).toEqual({
         transactions: searchTxsWithAllFiltersPoolRegistrationOrOperator,
-        total_count: 4,
+        total_count: 8,
         next_offset: 2
       });
     });
@@ -1929,7 +1960,7 @@ describe('/search/transactions endpoint', () => {
       expect(response.statusCode).toEqual(StatusCodes.OK);
       expect(response.json()).toEqual({
         transactions: searchTxWithAllFiltersPoolRetirementOrOperator,
-        total_count: 4,
+        total_count: 6,
         next_offset: 2
       });
     });
@@ -1952,7 +1983,7 @@ describe('/search/transactions endpoint', () => {
       expect(response.statusCode).toEqual(StatusCodes.OK);
       expect(response.json()).toEqual({
         transactions: searchTxWithAllFiltersDelegationsOrOperator,
-        total_count: 54,
+        total_count: 55,
         next_offset: 2
       });
     });
@@ -1975,7 +2006,7 @@ describe('/search/transactions endpoint', () => {
       expect(response.statusCode).toEqual(StatusCodes.OK);
       expect(response.json()).toEqual({
         transactions: searchTxWithAllFiltersDeregistrationsOrOperator,
-        total_count: 6,
+        total_count: 7,
         next_offset: 2
       });
     });
@@ -1998,7 +2029,7 @@ describe('/search/transactions endpoint', () => {
       expect(response.statusCode).toEqual(StatusCodes.OK);
       expect(response.json()).toEqual({
         transactions: searchTxWithAllFiltersStakeRegistrationOrOperator,
-        total_count: 25,
+        total_count: 26,
         next_offset: 2
       });
     });
@@ -2021,11 +2052,11 @@ describe('/search/transactions endpoint', () => {
       expect(response.statusCode).toEqual(StatusCodes.OK);
       expect(response.json()).toEqual({
         transactions: searchTxWithAllFiltersVoteRegistrationOrOperator,
-        total_count: 13,
+        total_count: 14,
         next_offset: 2
       });
     });
-    test('Should return transactions with withdrawal type, max block, coin, success, address and currency filters with OR operator', async () => {
+    test('Should return transactions with withdrawal type, max block, coin, success, address and currency filters with OR operator ', async () => {
       const response = await server.inject({
         method: 'post',
         url: SEARCH_TRANSACTIONS_ENDPOINT,
@@ -2044,7 +2075,7 @@ describe('/search/transactions endpoint', () => {
       expect(response.statusCode).toEqual(StatusCodes.OK);
       expect(response.json()).toEqual({
         transactions: searchTxWithAllFiltersWithdrawalOrOperator,
-        total_count: 38,
+        total_count: 39,
         next_offset: 2
       });
     });


### PR DESCRIPTION
# Description

Fixes a bug at `/search/transaction`, where it didn't return transactions where the coin was spent, making `coin` and `address` filters work incorrectly.

Closes #454 