### PR TITLE
chore: docker-compose cardano-node 1.35.2 & cardano-db-sync 13.0.2

### DIFF
--- a/cardano-rosetta-server/docker-compose.yml
+++ b/cardano-rosetta-server/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         max-size: "200k"
         max-file: "10"
   cardano-node:
-    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.35.0}
+    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.35.2}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     volumes:
@@ -34,7 +34,7 @@ services:
         max-size: "400k"
         max-file: "20"
   cardano-db-sync:
-    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.0.0}
+    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.0.2}
     command: [
       "--config", "/config/cardano-db-sync/config.json",
       "--socket-path", "/node-ipc/node.socket"


### PR DESCRIPTION
# Description

`Dockefile` and `docker-compose` files diverges on `cardano-db-sync 's`& `cardano-node`'s versions. 
Current docker-compose file is using older versions which contains a bug that prevents the node to get synched: `HardForkEnvelopeErrFromEra`.
This error was actually fixed in latest cardano-node 1.35.2 version at https://github.com/input-output-hk/ouroboros-network/pull/3891

