### PR TITLE
fix: nest protocol params inside metadata object of construction endpoint

### DIFF
--- a/cardano-rosetta-server/src/server/controllers/construction-controller.ts
+++ b/cardano-rosetta-server/src/server/controllers/construction-controller.ts
@@ -181,9 +181,8 @@ const configure = (
         logger.debug(`[constructionMetadata] suggested fee is ${suggestedFee}`);
         // eslint-disable-next-line camelcase
         return {
-          metadata: { ttl: ttl.toString() },
-          suggested_fee: [mapAmount(suggestedFee.toString())],
-          protocol_parameters: protocolParameters
+          metadata: { ttl: ttl.toString(), protocol_parameters: protocolParameters },
+          suggested_fee: [mapAmount(suggestedFee.toString())]
         };
       },
       request.log,

--- a/cardano-rosetta-server/src/server/openApi.json
+++ b/cardano-rosetta-server/src/server/openApi.json
@@ -1988,9 +1988,6 @@
             "items": {
               "$ref": "#/components/schemas/Amount"
             }
-          },
-          "protocol_parameters": {
-            "$ref": "#/components/schemas/ProtocolParameters"
           }
         }
       },
@@ -2038,7 +2035,7 @@
       "ConstructionPreprocessRequest": {
         "description": "ConstructionPreprocessRequest is passed to the `/construction/preprocess` endpoint so that a Rosetta implementation can determine which metadata it needs to request for construction. Metadata provided in this object should NEVER be a product of live data (i.e. the caller must follow some network-specific data fetching strategy outside of the Construction API to populate required Metadata). If live data is required for construction, it MUST be fetched in the call to `/construction/metadata`. The caller can provide a max fee they are willing to pay for a transaction. This is an array in the case fees must be paid in multiple currencies. The caller can also provide a suggested fee multiplier to indicate that the suggested fee should be scaled. This may be used to set higher fees for urgent transactions or to pay lower fees when there is less urgency. It is assumed that providing a very low multiplier (like 0.0001) will never lead to a transaction being created with a fee less than the minimum network fee (if applicable). In the case that the caller provides both a max fee and a suggested fee multiplier, the max fee will set an upper bound on the suggested fee (regardless of the multiplier provided).",
         "type": "object",
-        "required": ["network_identifier", "operations", "metadata"],
+        "required": ["network_identifier", "operations"],
         "properties": {
           "network_identifier": {
             "$ref": "#/components/schemas/NetworkIdentifier"

--- a/cardano-rosetta-server/src/types/rosetta-types.d.ts
+++ b/cardano-rosetta-server/src/types/rosetta-types.d.ts
@@ -401,7 +401,6 @@ declare namespace Components {
         protocol_parameters?: ProtocolParameters;
       };
       suggested_fee?: /* Amount is some Value of a Currency. It is considered invalid to specify a Value without a Currency. */ Amount[];
-      protocol_parameters?: ProtocolParameters;
     }
     /**
      * ConstructionParseRequest is the input to the `/construction/parse` endpoint. It allows the caller to parse either an unsigned or signed transaction.

--- a/cardano-rosetta-server/test/e2e/construction/construction-metadata-api.test.ts
+++ b/cardano-rosetta-server/test/e2e/construction/construction-metadata-api.test.ts
@@ -53,7 +53,8 @@ describe(CONSTRUCTION_METADATA_ENDPOINT, () => {
     expect(response.statusCode).toEqual(StatusCodes.OK);
     expect(response.json()).toEqual({
       metadata: {
-        ttl: (latestBlockSlot + relativeTtl).toString()
+        ttl: (latestBlockSlot + relativeTtl).toString(),
+        protocol_parameters: LATEST_EPOCH_PROTOCOL_PARAMS
       },
       suggested_fee: [
         {
@@ -67,8 +68,7 @@ describe(CONSTRUCTION_METADATA_ENDPOINT, () => {
             linearFeeParameters.minFeeB
           ).toString()
         }
-      ],
-      protocol_parameters: LATEST_EPOCH_PROTOCOL_PARAMS
+      ]
     });
   });
 


### PR DESCRIPTION
# Description

_A clear and concise description of what this pull request does or fixes._

A recent [commit](https://github.com/input-output-hk/cardano-rosetta/commit/ec56d250c2a231991dc2ad83221875c2ab47304d#diff-3e4a5ae0c3ef451b5fb71feaff4ae449d048c43a4943baf5b34ce18ce627fd16R186) introduced a bug where the response of `/construction/metadata` endpoint will respond with `protocol_parameter` outside the `metadata` object. This breaks the rosetta [spec](https://www.rosetta-api.org/docs/models/ConstructionMetadataResponse.html) and also in the subsequent `/construction/payloads` call, it is read from `req.body.metadata.protocol_parameter` which will return null.


# Proposed Solution

This fix moves the `protocol_parameter` in the `metadata`


_**Optional** Explain how does this PR solves the problem stated in [Description](#Description). You can also enumerate different alternatives considered while approaching this task._

# Important Changes Introduced

_**Optional** Notice Reviewers about changes that were introduced while developing this task_

# Testing

_**Optional** Leave some recommendations should be useful while reviewers are testing this PR_

